### PR TITLE
Feature/ioctls tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
   "Pogobanane <aenderboy@gmx.de>"
 ]
 edition = "2018"
+default-run = "vmsh"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -1,0 +1,38 @@
+use clap::{value_t, App, Arg};
+use nix::unistd::Pid;
+use simple_error::try_with;
+use vmsh::result::Result;
+
+use vmsh::kvm;
+
+fn inject(pid: Pid) -> Result<()> {
+    let vm = try_with!(
+        kvm::get_hypervisor(pid),
+        "cannot get vms for process {}",
+        pid
+    );
+
+    print!("check_extensions");
+    for _ in 1..100 {
+        let tracee = vm.attach()?;
+        try_with!(tracee.check_extension(0), "cannot query kvm extensions");
+        print!(".")
+    }
+    println!(" ok");
+
+    Ok(())
+}
+
+fn main() {
+    let app = App::new("test_ioctls")
+        .about("Something between integration and unit test to be used by pytest.")
+        .arg(Arg::with_name("pid").required(true).index(1));
+    let matches = app.get_matches();
+    let pid = value_t!(matches, "pid", i32).unwrap_or_else(|e| e.exit());
+    let pid = Pid::from_raw(pid);
+
+    if let Err(err) = inject(pid) {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}

--- a/src/bin/vmsh.rs
+++ b/src/bin/vmsh.rs
@@ -1,22 +1,7 @@
-mod attach;
-mod coredump;
-mod cpu;
-mod device;
-mod elf;
-mod gdb_break;
-mod inject_syscall;
-mod inspect;
-mod kvm;
-mod kvm_ioctls;
-mod kvm_memslots;
-mod page_math;
-mod proc;
-mod ptrace;
-mod result;
-
-use crate::inspect::InspectOptions;
 use clap::{crate_authors, crate_version, value_t, App, AppSettings, Arg, ArgMatches, SubCommand};
 use nix::unistd::Pid;
+use vmsh::inspect::InspectOptions;
+use vmsh::{attach, coredump, inspect};
 
 fn pid_arg(index: u64) -> Arg<'static, 'static> {
     Arg::with_name("pid")

--- a/src/inject_syscall.rs
+++ b/src/inject_syscall.rs
@@ -57,7 +57,7 @@ pub fn attach(pid: Pid) -> Result<Process> {
         "cannot get text for main process"
     );
     try_with!(
-        threads[process_idx].write(ip as *mut c_void, cpu::SYSCALL_TEXT as *mut c_void),
+        unsafe { threads[process_idx].write(ip as *mut c_void, cpu::SYSCALL_TEXT as *mut c_void) },
         "cannot patch syscall instruction"
     );
 
@@ -196,10 +196,12 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
-        let _ = self.main_thread().write(
-            self.saved_regs.ip() as *mut c_void,
-            self.saved_text as *mut c_void,
-        );
+        let _ = unsafe {
+            self.main_thread().write(
+                self.saved_regs.ip() as *mut c_void,
+                self.saved_text as *mut c_void,
+            )
+        };
         let _ = self.main_thread().setregs(&self.saved_regs);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod attach;
+pub mod coredump;
+pub mod cpu;
+pub mod device;
+pub mod elf;
+pub mod gdb_break;
+pub mod inject_syscall;
+pub mod inspect;
+pub mod kvm;
+pub mod kvm_ioctls;
+pub mod kvm_memslots;
+pub mod page_math;
+pub mod proc;
+pub mod ptrace;
+pub mod result;

--- a/src/ptrace.rs
+++ b/src/ptrace.rs
@@ -76,14 +76,12 @@ impl Thread {
         ))
     }
 
-    pub fn write(&self, addr: AddressType, data: *mut c_void) -> Result<()> {
-        unsafe {
-            try_with!(
-                ptrace::write(self.tid, addr, data),
-                "cannot write with ptrace"
-            );
-            Ok(())
-        }
+    pub unsafe fn write(&self, addr: AddressType, data: *mut c_void) -> Result<()> {
+        try_with!(
+            ptrace::write(self.tid, addr, data),
+            "cannot write with ptrace"
+        );
+        Ok(())
     }
 }
 


### PR DESCRIPTION
moves src/main.rs to src/bin/vmsh.rs. This bin/ allows us to conveniently create may binaries from our codebase (src/) which is now a lib.rs. It also allows to create another executable for testing instead of adding testing subcommands to vmsh. 

This PR adds a test_ioctls binary which is called by the pytest test to test ioctl injection into a running kvm vmm: `cargo run --bin test_ioctls -- <qemu pid>`. 