### PR TITLE
Feature/with ref ioctls

### DIFF
--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -31,7 +31,7 @@ fn mmap(pid: Pid) -> Result<()> {
     );
 
     let tracee = vm.attach()?;
-    let addr = try_with!(tracee.malloc(4), "malloc failed");
+    let addr = try_with!(tracee.mmap(4), "mmap failed");
     assert_eq!(vm.read::<u32>(addr)?, 0);
     vm.write::<u32>(addr, &0xdeadbeef)?;
     assert_eq!(vm.read::<u32>(addr)?, 0xdeadbeef);

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -32,9 +32,9 @@ fn mmap(pid: Pid) -> Result<()> {
 
     let tracee = vm.attach()?;
     let addr = try_with!(tracee.malloc(4), "malloc failed");
-    assert_eq!(vm.read_u32(addr as usize)?, 0);
-    vm.write_u32(addr as usize, 0xdeadbeef);
-    assert_eq!(vm.read_u32(addr as usize)?, 0xdeadbeef);
+    assert_eq!(vm.read::<u32>(addr)?, 0);
+    vm.write::<u32>(addr, &0xdeadbeef)?;
+    assert_eq!(vm.read::<u32>(addr)?, 0xdeadbeef);
 
     Ok(())
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -3,7 +3,6 @@ mod virtio;
 use crate::device::virtio::block::{self, BlockArgs};
 use crate::device::virtio::{CommonArgs, MmioConfig};
 use crate::kvm::Hypervisor;
-use crate::kvm_memslots;
 use crate::proc::Mapping;
 use crate::result::Result;
 use event_manager::{EventManager, MutEventSubscriber};
@@ -71,7 +70,8 @@ pub struct Device {
 
 impl Device {
     pub fn new(vmm: &Arc<Hypervisor>) -> Result<Device> {
-        let guest_memory = try_with!(kvm_memslots::get_maps(vmm), "cannot get guests memory");
+        let tracee = try_with!(vmm.attach(), "cannot attach");
+        let guest_memory = try_with!(tracee.get_maps(), "cannot get guests memory");
         let mem: Arc<GuestMemoryMmap> = Arc::new(try_with!(
             convert(&guest_memory),
             "cannot convert Mapping to GuestMemoryMmap"

--- a/src/inject_syscall.rs
+++ b/src/inject_syscall.rs
@@ -1,5 +1,5 @@
-use libc::{c_int, c_long, c_ulong, c_void, pid_t};
-use libc::{SYS_getpid, SYS_ioctl};
+use libc::{c_int, c_long, c_ulong, c_void, off_t, pid_t, size_t};
+use libc::{SYS_getpid, SYS_ioctl, SYS_mmap};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::sys::{signal::Signal, wait::WaitPidFlag};
 use nix::unistd::Pid;
@@ -141,6 +141,42 @@ impl Process {
         let args = syscall_args!(self.saved_regs, SYS_getpid as c_ulong);
 
         self.syscall(&args).map(|v| v as c_int)
+    }
+
+    pub fn mmap(
+        &self,
+        addr: *mut c_void,
+        length: size_t,
+        prot: c_int,
+        flags: c_int,
+        fd: RawFd,
+        offset: off_t,
+    ) -> Result<*mut c_void> {
+        let args = syscall_args!(
+            self.saved_regs,
+            SYS_mmap as c_ulong,
+            addr,
+            length,
+            prot,
+            flags,
+            fd,
+            offset
+        );
+
+        self.syscall(&args).map(|v| v as *mut c_void)
+    }
+
+    pub fn munmap(&self) -> Result<()> {
+        // TODO
+        unimplemented!();
+    }
+
+    pub fn open(&self) -> Result<c_int> {
+        unimplemented!();
+    }
+
+    pub fn write(&self) -> Result<()> {
+        unimplemented!();
     }
 
     fn syscall(&self, regs: &Regs) -> Result<isize> {

--- a/src/inject_syscall.rs
+++ b/src/inject_syscall.rs
@@ -124,7 +124,7 @@ macro_rules! syscall_args {
 }
 
 impl Process {
-    pub fn ioctl(&self, fd: RawFd, request: c_ulong, arg: c_int) -> Result<c_int> {
+    pub fn ioctl(&self, fd: RawFd, request: c_ulong, arg: c_ulong) -> Result<c_int> {
         let args = syscall_args!(
             self.saved_regs,
             SYS_ioctl as c_ulong,

--- a/tests/test_ioctl_injection.py
+++ b/tests/test_ioctl_injection.py
@@ -3,4 +3,6 @@ import conftest
 
 def test_ioctl_injection(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
-        helpers.run_vmsh_command(["inject", str(vm.pid)], cargo_options=["--bin", "test_ioctls"])
+        helpers.run_vmsh_command(
+            ["inject", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+        )

--- a/tests/test_ioctl_mmap.py
+++ b/tests/test_ioctl_mmap.py
@@ -3,4 +3,4 @@ import conftest
 
 def test_ioctl_injection(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
-        helpers.run_vmsh_command(["inject", str(vm.pid)], cargo_options=["--bin", "test_ioctls"])
+        helpers.run_vmsh_command(["mmap", str(vm.pid)], cargo_options=["--bin", "test_ioctls"])


### PR DESCRIPTION
adds Tracee:ioctl_with_ref which takes a pointer to a struct (of which the type is encoded in the ioctl type). This struct is allocated in the tracees memory space.

TODO: free

Also: testing ioctl_with_ref with creating KVM_IOEVENTFD and addig KVM_SET_USER_MEMORY_REGION (not included in this PR) did not succeed yet. 