### PR TITLE
Feature/kvm debugging

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ sign-drone:
     nix-shell -p drone-cli --run 'drone sign Mic92/vmsh --save'
 
 build-linux-shell:
-  nix-shell {{invocation_directory()}}/nix/fhs-shell.nix
+  nix-shell {{invocation_directory()}}/nix/kernel-fhs-shell.nix
 
 build-linux: configure-linux
   {{kernel_fhs}} "yes \n | make -C {{linux_dir}} -j$(nproc)"
@@ -71,7 +71,7 @@ qemu: build-linux nixos-image
     -netdev user,id=user.0,hostfwd=tcp::2222-:22 \
     -m 512M \
     -cpu host \
-    -virtfs local,path=/home/okelmann,security_model=none,mount_tag=home \
+    -virtfs local,path={{invocation_directory()}}/..,security_model=none,mount_tag=home \
     -nographic -enable-kvm \
     -s
 

--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ configure-linux: clone-linux
     {{kernel_fhs}} "yes \n | scripts/config --set-val DEBUG_DRIVER y"
     {{kernel_fhs}} "yes \n | scripts/config --set-val KVM y"
     {{kernel_fhs}} "yes \n | scripts/config --set-val KVM_INTEL y"
+    {{kernel_fhs}} "yes \n | scripts/config --set-val BPF_SYSCALL y"
   fi
 
 sign-drone:

--- a/justfile
+++ b/justfile
@@ -37,6 +37,8 @@ configure-linux: clone-linux
     {{kernel_fhs}} "yes \n | scripts/config --set-val DEBUG y"
     {{kernel_fhs}} "yes \n | scripts/config --set-val GDB_SCRIPTS y"
     {{kernel_fhs}} "yes \n | scripts/config --set-val DEBUG_DRIVER y"
+    {{kernel_fhs}} "yes \n | scripts/config --set-val KVM y"
+    {{kernel_fhs}} "yes \n | scripts/config --set-val KVM_INTEL y"
   fi
 
 sign-drone:

--- a/nix/nixos-image.nix
+++ b/nix/nixos-image.nix
@@ -33,7 +33,7 @@ in import (pkgs.path + "/nixos/lib/make-disk-image.nix") {
         and `quit` to stop the VM.
       '';
       documentation.doc.enable = false;
-      environment.systemPackages = [ pkgs.kmod ];
+      environment.systemPackages = [ pkgs.kmod pkgs.qemu ];
     })];
   }).config;
   partitionTableType = "none";

--- a/nix/nixos-image.nix
+++ b/nix/nixos-image.nix
@@ -33,7 +33,7 @@ in import (pkgs.path + "/nixos/lib/make-disk-image.nix") {
         and `quit` to stop the VM.
       '';
       documentation.doc.enable = false;
-      environment.systemPackages = [ pkgs.kmod pkgs.qemu ];
+      environment.systemPackages = [ pkgs.kmod pkgs.qemu pkgs.linuxPackages.bcc ];
     })];
   }).config;
   partitionTableType = "none";

--- a/qemu_nested.sh
+++ b/qemu_nested.sh
@@ -4,7 +4,7 @@
 
 linux_dir=../linux
 
-sudo qemu-system-x86_64 \
+qemu-system-x86_64 \
   -kernel $linux_dir/arch/x86/boot/bzImage \
   -hda $linux_dir/nixos_nested.qcow2 \
   -append "root=/dev/sda console=ttyS0 nokaslr" \

--- a/qemu_nested.sh
+++ b/qemu_nested.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#mkdir /mnt
+#mount -t 9p -o trans=virtio home /mnt
+
+linux_dir=../linux
+
+sudo qemu-system-x86_64 \
+  -kernel $linux_dir/arch/x86/boot/bzImage \
+  -hda $linux_dir/nixos_nested.qcow2 \
+  -append "root=/dev/sda console=ttyS0 nokaslr" \
+  -m 256M \
+  -nographic -enable-kvm

--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ pkgs.mkShell {
     (pkgs.python3.withPackages(ps: [ps.pytest ps.black ps.flake8 ps.mypy]))
 
     pkgs.qemu_kvm
+    pkgs.gdb
     pkgs.tmux # needed for integration test
   ] ++ vmsh.nativeBuildInputs;
   buildInputs = vmsh.buildInputs;

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -120,7 +120,7 @@ fn guest_ioeventfd(pid: Pid) -> Result<()> {
         datamatch: 0,
         len: 8,
         addr: 0xfffffff0,
-        fd: ioeventfd_fd.as_raw_fd(),
+        fd: ioeventfd_fd.as_raw_fd(), // thats why we get -22 EINVAL
         flags: 0,
         ..Default::default()
     };

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -1,6 +1,8 @@
 use clap::{value_t, App, Arg, SubCommand};
+use kvm_bindings as kvmb;
 use nix::unistd::Pid;
-use simple_error::try_with;
+use simple_error::{bail, try_with};
+use vmsh::kvm::ioctls;
 use vmsh::result::Result;
 
 use vmsh::kvm;
@@ -39,6 +41,52 @@ fn mmap(pid: Pid) -> Result<()> {
     Ok(())
 }
 
+fn guest_add_mem(pid: Pid) -> Result<()> {
+    let vm = try_with!(
+        kvm::get_hypervisor(pid),
+        "cannot get vms for process {}",
+        pid
+    );
+    let tracee = vm.attach()?;
+
+    // count memslots
+    let memslots_a = tracee.get_maps()?;
+    memslots_a.iter().for_each(|map| {
+        println!(
+            "vm mem: 0x{:x} -> 0x{:x} (physical: 0x{:x}, flags: {:?} | {:?})",
+            map.start, map.end, map.phys_addr, map.prot_flags, map.map_flags,
+        )
+    });
+    println!("--");
+
+    // add memslot
+    let slot_len = 0x10;
+    let hv_memslot_addr = tracee.mmap(slot_len)?;
+    let arg = kvmb::kvm_userspace_memory_region {
+        slot: memslots_a.len() as u32,
+        flags: 0, // maybe KVM_MEM_READONLY
+        guest_phys_addr: 0xd0000000,
+        memory_size: slot_len as u64,
+        userspace_addr: hv_memslot_addr as u64,
+    };
+    let ret = tracee.vm_ioctl_with_ref(ioctls::KVM_SET_USER_MEMORY_REGION(), &arg)?;
+    if ret != 0 {
+        bail!("ioctl_with_ref failed: {}", ret)
+    }
+
+    // count memslots again
+    let memslots_b = tracee.get_maps()?;
+    memslots_b.iter().for_each(|map| {
+        println!(
+            "vm mem: 0x{:x} -> 0x{:x} (physical: 0x{:x}, flags: {:?} | {:?})",
+            map.start, map.end, map.phys_addr, map.prot_flags, map.map_flags,
+        )
+    });
+    assert_eq!(memslots_a.len(), memslots_b.len());
+
+    Ok(())
+}
+
 fn subtest(name: &str) -> App {
     SubCommand::with_name(name).arg(Arg::with_name("pid").required(true).index(1))
 }
@@ -47,7 +95,8 @@ fn main() {
     let app = App::new("test_ioctls")
         .about("Something between integration and unit test to be used by pytest.")
         .subcommand(subtest("mmap"))
-        .subcommand(subtest("inject"));
+        .subcommand(subtest("inject"))
+        .subcommand(subtest("guest_add_mem"));
 
     let matches = app.get_matches();
     let subcommand_name = matches.subcommand_name().expect("subcommad required");
@@ -58,6 +107,7 @@ fn main() {
     let result = match subcommand_name {
         "mmap" => mmap(pid),
         "inject" => inject(pid),
+        "guest_add_mem" => guest_add_mem(pid),
         _ => std::process::exit(2),
     };
 

--- a/src/inject_syscall.rs
+++ b/src/inject_syscall.rs
@@ -167,7 +167,7 @@ impl Process {
     }
 
     pub fn munmap(&self) -> Result<()> {
-        // TODO
+        // TODO SYS_munmap
         unimplemented!();
     }
 


### PR DESCRIPTION
WIP impl for 
- guest_add_mem (KVM_SET_USER_MEMORY_REGION): `cargo run --bin test_ioctls -- guest_add_mem <pid>`
- guest_ioeventfd (KVM_IOEVENTFD): `cargo run --bin test_ioctls -- guest_ioeventfd <pid>`

...which fail with -22 EINVAL (for example in [kernel/kvm_ioeventfd()](https://github.com/torvalds/linux/blob/f296bfd5cd04cbb49b8fc9585adc280ab2b58624/virt/kvm/eventfd.c#L963)). Therefore this PR also enables debugging a kvm running in qemu with gdb. Example:
- host: just qemu -> guest1
- host: `ssh -p 2222 -i ~/.ssh/* root@localhost`
- guest1: `mkdir /mnt && mount -t 9p -o trans=virtio home /mnt && cd /mnt/vmsh`
- guest1: `./nested_qemu.sh` -> guest2
- host: attach gdb to guest1 and set breakpoint at some kvm_* function
- guest1: `././target/debug/test_ioctls guest_ioeventfd <nested_qemu pid>`