### PR TITLE
Feature/add mem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
       - name: Install bcc
-        run: sudo apt install libbpfcc musl-tools
+        run: |
+          # ubuntu forgot to set a soname symlink somehow
+          sudo apt install libbpfcc musl-tools && sudo ln -s /usr/lib/x86_64-linux-gnu/libbcc.so.0 /usr/lib/x86_64-linux-gnu/libbcc.so
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -61,50 +61,45 @@ fn alloc_mem(pid: Pid) -> Result<()> {
 }
 
 fn guest_add_mem(pid: Pid, re_get_slots: bool) -> Result<()> {
-    let vm = try_with!(
-        kvm::get_hypervisor(pid),
-        "cannot get vms for process {}",
-        pid
-    );
-    let tracee = vm.attach()?;
+    {
+        let vm = try_with!(
+            kvm::get_hypervisor(pid),
+            "cannot get vms for process {}",
+            pid
+        );
+        let tracee = vm.attach()?;
 
-    // count memslots
-    let memslots_a = tracee.get_maps()?;
-    memslots_a.iter().for_each(|map| {
-        println!(
-            "vm mem: 0x{:x} -> 0x{:x} (physical: 0x{:x}, flags: {:?} | {:?})",
-            map.start, map.end, map.phys_addr, map.prot_flags, map.map_flags,
-        )
-    });
-    println!("--");
-
-    // add memslot
-    let slot_len = 4096; // must be a multiple of PAGESIZE
-    let hv_memslot = tracee.alloc_mem_padded::<u64>(slot_len)?;
-    let arg = kvmb::kvm_userspace_memory_region {
-        slot: memslots_a.len() as u32,
-        flags: 0x00,                 // maybe KVM_MEM_READONLY
-        guest_phys_addr: 0xd0000000, // must be page aligned
-        memory_size: slot_len as u64,
-        userspace_addr: hv_memslot.ptr as u64,
-    };
-    let ret = tracee.vm_ioctl_with_ref(ioctls::KVM_SET_USER_MEMORY_REGION(), &arg)?;
-    if ret != 0 {
-        bail!("ioctl_with_ref failed: {}", ret)
-    }
-
-    if re_get_slots {
-        // count memslots again
-        let memslots_b = tracee.get_maps()?;
-        memslots_b.iter().for_each(|map| {
+        // count memslots
+        let memslots_a = tracee.get_maps()?;
+        memslots_a.iter().for_each(|map| {
             println!(
                 "vm mem: 0x{:x} -> 0x{:x} (physical: 0x{:x}, flags: {:?} | {:?})",
                 map.start, map.end, map.phys_addr, map.prot_flags, map.map_flags,
             )
         });
-        assert_eq!(memslots_a.len() + 1, memslots_b.len());
-    }
+        println!("--");
 
+        // add memslot
+        let slot_len = 4096; // must be a multiple of PAGESIZE
+        let hv_memslot = tracee.alloc_mem_padded::<u32>(slot_len)?;
+        tracee.vm_add_mem(slot_len, &hv_memslot)?;
+
+        if re_get_slots {
+            // count memslots again
+            let memslots_b = tracee.get_maps()?;
+            memslots_b.iter().for_each(|map| {
+                println!(
+                    "vm mem: 0x{:x} -> 0x{:x} (physical: 0x{:x}, flags: {:?} | {:?})",
+                    map.start, map.end, map.phys_addr, map.prot_flags, map.map_flags,
+                )
+            });
+            assert_eq!(memslots_a.len() + 1, memslots_b.len());
+        }
+        println!("in scope. sleeping");
+        std::thread::sleep(std::time::Duration::from_secs(20));
+    }
+    println!("out of scope. sleeping");
+    std::thread::sleep(std::time::Duration::from_secs(20));
     Ok(())
 }
 

--- a/src/kvm/mod.rs
+++ b/src/kvm/mod.rs
@@ -28,7 +28,7 @@ use crate::result::Result;
 pub struct Tracee {
     pid: Pid,
     vm_fd: RawFd,
-    proc: inject_syscall::Process, // make optional and implement play/pause
+    proc: inject_syscall::Process, // TODO make optional and implement play/pause
 }
 
 pub struct TraceeMem<'a, T: Copy> {


### PR DESCRIPTION
adds `Tracee::vm_add_mem<T>` which adds memory for T and returns a `VmMem`. Memory is therefore automatically de-registered (and via TraceeMem also freed).