### PR TITLE
Feature/blk events

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,6 +41,8 @@ configure-linux: clone-linux
     {{kernel_fhs}} "scripts/config --set-val KVM_INTEL y"
     {{kernel_fhs}} "scripts/config --set-val BPF_SYSCALL y"
     {{kernel_fhs}} "scripts/config --set-val IKHEADERS y"
+    {{kernel_fhs}} "scripts/config --set-val VIRTIO_MMIO m"
+    {{kernel_fhs}} "scripts/config --set-val VIRTIO_MMIO_CMDLINE_DEVICES y"
   fi
 
 sign-drone:

--- a/nix/not-os-image.nix
+++ b/nix/not-os-image.nix
@@ -5,13 +5,12 @@ let
   inherit (pkgs) stdenv lib;
   inherit (pkgs.pkgsMusl.hostPlatform) system parsed;
   useMusl = false;
-# TODO remove
-#  foobars = pkgs.makeModulesClosure {
-#    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules ++ [ "virtio_mmio" ];
-#    allowMissing = true;
-#    kernel = config.system.build.kernel;
-#    firmware = config.hardware.firmware;
-#  };
+  modules = pkgs.makeModulesClosure {
+    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules ++ [ "virtio_mmio" ];
+    allowMissing = true;
+    kernel = config.system.build.kernel;
+    firmware = config.hardware.firmware;
+  };
 
   config = (import not-os {
     nixpkgs = pkgs.path;
@@ -47,7 +46,7 @@ let
       '';
 
       boot.initrd.availableKernelModules = [ "virtio_console" "virtio_mmio" ];
-      boot.initrd.kernelModules = [ "virtio_mmio" ];
+      # to activate at boot time: boot.initrd.kernelModules = [ "virtio_mmio" ];
 
       environment.etc = {
         "hosts".text = ''
@@ -77,6 +76,7 @@ let
       };
       environment.etc.profile.text = ''
         export PS1="\e[0;32m[\u@\h \w]\$ \e[0m"
+        export MODULE_DRIVERS_DIR="${modules}/lib/modules/$(uname -r)/kernel/drivers"
       '';
     };
   }).config;

--- a/nix/not-os-image.nix
+++ b/nix/not-os-image.nix
@@ -5,6 +5,13 @@ let
   inherit (pkgs) stdenv lib;
   inherit (pkgs.pkgsMusl.hostPlatform) system parsed;
   useMusl = false;
+# TODO remove
+#  foobars = pkgs.makeModulesClosure {
+#    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules ++ [ "virtio_mmio" ];
+#    allowMissing = true;
+#    kernel = config.system.build.kernel;
+#    firmware = config.hardware.firmware;
+#  };
 
   config = (import not-os {
     nixpkgs = pkgs.path;
@@ -17,7 +24,12 @@ let
         pkgs.utillinux
         pkgs.gnugrep
         pkgs.kmod
+        pkgs.findutils
       ];
+      # boot.initrd.availableKernelModules = [ "ext3" "virtio_mmio" ];
+      # lib.modules.rootModules = [ "ext3" "virtio_mmio" ];
+      #lib.modules.allowMissing = false;
+
       nixpkgs.localSystem = lib.mkIf useMusl {
         inherit system parsed;
       };
@@ -27,12 +39,15 @@ let
       not-os.nix = true;
       not-os.simpleStaticIp = true;
       not-os.preMount = ''
-        echo 'nixos' > /proc/sys/kernel/hostname
+        echo 'nixos2' > /proc/sys/kernel/hostname
         ip addr add 127.0.0.1/8 dev lo
         ip addr add ::1/128 dev lo
         ip link dev lo up
         ip addr add 10.0.2.15/24 dev eth0
       '';
+
+      boot.initrd.availableKernelModules = [ "virtio_console" "virtio_mmio" ];
+      boot.initrd.kernelModules = [ "virtio_mmio" ];
 
       environment.etc = {
         "hosts".text = ''
@@ -63,7 +78,6 @@ let
       environment.etc.profile.text = ''
         export PS1="\e[0;32m[\u@\h \w]\$ \e[0m"
       '';
-      boot.initrd.availableKernelModules = [ "virtio_console" ];
     };
   }).config;
 in

--- a/nix/not-os-image.nix
+++ b/nix/not-os-image.nix
@@ -23,12 +23,7 @@ let
         pkgs.utillinux
         pkgs.gnugrep
         pkgs.kmod
-        pkgs.findutils
       ];
-      # boot.initrd.availableKernelModules = [ "ext3" "virtio_mmio" ];
-      # lib.modules.rootModules = [ "ext3" "virtio_mmio" ];
-      #lib.modules.allowMissing = false;
-
       nixpkgs.localSystem = lib.mkIf useMusl {
         inherit system parsed;
       };
@@ -38,7 +33,7 @@ let
       not-os.nix = true;
       not-os.simpleStaticIp = true;
       not-os.preMount = ''
-        echo 'nixos2' > /proc/sys/kernel/hostname
+        echo 'nixos' > /proc/sys/kernel/hostname
         ip addr add 127.0.0.1/8 dev lo
         ip addr add ::1/128 dev lo
         ip link dev lo up
@@ -47,6 +42,14 @@ let
 
       boot.initrd.availableKernelModules = [ "virtio_console" "virtio_mmio" ];
       # to activate at boot time: boot.initrd.kernelModules = [ "virtio_mmio" ];
+      boot.kernelPatches = [ {
+        name = "virtio-mmio-cmdline";
+        patch = null;
+        extraConfig = ''
+                VIRTIO_MMIO_CMDLINE_DEVICES y
+              '';
+        } ];
+
 
       environment.etc = {
         "hosts".text = ''

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -3,6 +3,7 @@
 use crate::result::Result;
 use simple_error::try_with;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::device::Device;
 use crate::inspect::InspectOptions;
@@ -23,6 +24,6 @@ pub fn attach(opts: &InspectOptions) -> Result<()> {
     device.create();
     device.create();
     println!("pause");
-    std::thread::sleep_ms(999999999);
+    std::thread::sleep(Duration::from_secs(99999));
     Ok(())
 }

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -3,7 +3,6 @@
 use crate::result::Result;
 use simple_error::try_with;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::device::Device;
 use crate::inspect::InspectOptions;
@@ -24,6 +23,6 @@ pub fn attach(opts: &InspectOptions) -> Result<()> {
     device.create();
     device.create();
     println!("pause");
-    std::thread::sleep(Duration::from_secs(99999));
+    nix::unistd::pause();
     Ok(())
 }

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -11,14 +11,18 @@ use crate::kvm;
 pub fn attach(opts: &InspectOptions) -> Result<()> {
     println!("attaching");
 
-    let vm = try_with!(
+    let vm = Arc::new(try_with!(
         kvm::hypervisor::get_hypervisor(opts.pid),
         "cannot get vms for process {}",
         opts.pid
-    );
+    ));
+    vm.stop()?;
 
-    let device = try_with!(Device::new(&Arc::new(vm)), "cannot create vm");
+    let device = try_with!(Device::new(&vm.clone()), "cannot create vm");
+    vm.resume()?;
     device.create();
     device.create();
+    println!("pause");
+    std::thread::sleep_ms(999999999);
     Ok(())
 }

--- a/src/device/mmio.rs
+++ b/src/device/mmio.rs
@@ -11,6 +11,7 @@ const MMIO_VERSION: u32 = 2;
 const VENDOR_ID: u32 = 0;
 
 /// padX fields are reserved for future use.
+#[derive(Copy, Clone, Debug)]
 #[repr(C)] // actually we want packed. Because that has undefined behaviour in rust 2018 we hope that C is effectively the same.
 pub struct MmioDeviceSpace {
     magic_value: u32,
@@ -60,7 +61,7 @@ use vm_virtio::Queue;
 type Block = block::Block<Arc<GuestMemoryMmap>>;
 
 impl MmioDeviceSpace {
-    fn new(device: Block) -> MmioDeviceSpace {
+    pub fn new(device: &Block) -> MmioDeviceSpace {
         let space = MmioDeviceSpace {
             magic_value: MMIO_MAGIC_VALUE,
             version: MMIO_VERSION,

--- a/src/device/mmio.rs
+++ b/src/device/mmio.rs
@@ -1,0 +1,116 @@
+// Required by the Virtio MMIO device register layout at offset 0 from base. Turns out this
+// is actually the ASCII sequence for "virt" (in little endian ordering).
+const MMIO_MAGIC_VALUE: u32 = 0x7472_6976;
+
+// Current version specified by the Virtio standard (legacy devices used 1 here).
+const MMIO_VERSION: u32 = 2;
+
+// TODO: Crosvm was using 0 here a while ago, and Firecracker started doing that as well. Should
+// we leave it like that, or should we use the VENDOR_ID value for PCI Virtio devices? It looks
+// like the standard doesn't say anything regarding an actual VENDOR_ID value for MMIO devices.
+const VENDOR_ID: u32 = 0;
+
+/// padX fields are reserved for future use.
+#[repr(C)] // actually we want packed. Because that has undefined behaviour in rust 2018 we hope that C is effectively the same.
+pub struct MmioDeviceSpace {
+    magic_value: u32,
+    version: u32,
+    device_id: u32,
+    vendor_id: u32,
+    device_features: u32,
+    device_features_sel: u32,
+    pad1: [u32; 2],
+    driver_features: u32,
+    /// beyond 32bit there are further feature bits reserved for future use
+    driver_features_sel: u32,
+    pad2: [u32; 2],
+    queue_sel: u32,
+    queue_num_max: u32,
+    queue_num: u32,
+    pad3: [u32; 2],
+    queue_ready: u32,
+    pad4: [u32; 2],
+    queue_notify: u32,
+    pad5: [u32; 3],
+    interrupt_status: u32,
+    interrupt_ack: u32,
+    pad6: [u32; 2],
+    status: u32,
+    pad7: [u32; 3],
+    /// 64bit phys addr
+    queue_desc_low: u32,
+    queue_desc_high: u32,
+    pad8: [u32; 2],
+    queue_driver_low: u32,
+    queue_driver_high: u32,
+    pad9: [u32; 2],
+    queue_device_low: u32,
+    queue_device_high: u32,
+    pad10: [u32; 21],
+    config_generation: u32,
+    // optional additional config space: config: [u8; n]
+}
+
+use crate::device::virtio::block;
+use std::sync::Arc;
+use vm_memory::{GuestMemoryMmap, GuestRegionMmap};
+use vm_virtio::device::{VirtioDevice, WithDriverSelect};
+use vm_virtio::Queue;
+
+type Block = block::Block<Arc<GuestMemoryMmap>>;
+
+impl MmioDeviceSpace {
+    fn new(device: Block) -> MmioDeviceSpace {
+        let space = MmioDeviceSpace {
+            magic_value: MMIO_MAGIC_VALUE,
+            version: MMIO_VERSION,
+            device_id: device.device_type(),
+            vendor_id: VENDOR_ID,
+            device_features: device.device_features(device.device_features_select()),
+            device_features_sel: 0,
+            pad1: [0u32; 2],
+            driver_features: 0, // TODO properly init this field and others
+            driver_features_sel: 0,
+            pad2: [0u32; 2],
+            queue_sel: 0,
+            queue_num_max: device
+                .selected_queue()
+                .map(Queue::max_size)
+                .unwrap_or(0)
+                .into(),
+            queue_num: 0,
+            pad3: [0u32; 2],
+            queue_ready: 0,
+            pad4: [0u32; 2],
+            queue_notify: 0,
+            pad5: [0u32; 3],
+            interrupt_status: 0,
+            interrupt_ack: 0,
+            pad6: [0u32; 2],
+            status: device.device_status().into(),
+            pad7: [0u32; 3],
+            queue_desc_low: 0,
+            queue_desc_high: 0,
+            pad8: [0u32; 2],
+            queue_driver_low: 0,
+            queue_driver_high: 0,
+            pad9: [0u32; 2],
+            queue_device_low: 0,
+            queue_device_high: 0,
+            pad10: [0u32; 21],
+            config_generation: device.config_generation().into(),
+        };
+
+        space
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn assert_mmio_device_space_size() {
+        use crate::device::mmio::MmioDeviceSpace;
+        use std::mem::size_of;
+        assert_eq!(0x100, size_of::<MmioDeviceSpace>());
+    }
+}

--- a/src/device/mmio.rs
+++ b/src/device/mmio.rs
@@ -62,7 +62,7 @@ type Block = block::Block<Arc<GuestMemoryMmap>>;
 
 impl MmioDeviceSpace {
     pub fn new(device: &Block) -> MmioDeviceSpace {
-        let space = MmioDeviceSpace {
+        MmioDeviceSpace {
             magic_value: MMIO_MAGIC_VALUE,
             version: MMIO_VERSION,
             device_id: device.device_type(),
@@ -100,9 +100,7 @@ impl MmioDeviceSpace {
             queue_device_high: 0,
             pad10: [0u32; 21],
             config_generation: device.config_generation().into(),
-        };
-
-        space
+        }
     }
 }
 

--- a/src/device/mmio.rs
+++ b/src/device/mmio.rs
@@ -54,7 +54,7 @@ pub struct MmioDeviceSpace {
 
 use crate::device::virtio::block;
 use std::sync::Arc;
-use vm_memory::{GuestMemoryMmap, GuestRegionMmap};
+use vm_memory::GuestMemoryMmap;
 use vm_virtio::device::{VirtioDevice, WithDriverSelect};
 use vm_virtio::Queue;
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,3 +1,4 @@
+mod mmio;
 mod virtio;
 
 use crate::device::virtio::block::{self, BlockArgs};

--- a/src/kvm/ioctls.rs
+++ b/src/kvm/ioctls.rs
@@ -202,6 +202,9 @@ ioctl_io_nr!(KVM_CHECK_EXTENSION, KVMIO, 0x03);
 // Available with KVM_CAP_IOEVENTFD
 ioctl_iow_nr!(KVM_IOEVENTFD, KVMIO, 0x79, kvmb::kvm_ioeventfd);
 
+// Available with KVM_CAP_IRQFD
+ioctl_iow_nr!(KVM_IRQFD, KVMIO, 0x76, kvmb::kvm_irqfd);
+
 // Avaulable with KVM_CAP_USER_MEMORY
 ioctl_iow_nr!(
     KVM_SET_USER_MEMORY_REGION,

--- a/tests/qemu.py
+++ b/tests/qemu.py
@@ -144,6 +144,14 @@ class QemuVm:
                 pass
             time.sleep(1)
 
+    def ssh_cmd_sh(self, sh_cmd: str) -> subprocess.CompletedProcess:
+        """
+        can be used for shell commands which require environment variables from
+        the VMs /etc/profile
+        """
+        sh_cmd = f"source /etc/profile && {sh_cmd}"
+        return self.ssh_cmd(["sh", "-c", sh_cmd])
+
     def ssh_cmd(
         self,
         argv: List[str],

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -6,6 +6,9 @@ def test_this_test(helpers: conftest.Helpers) -> None:
         print("wait for ssh")
         vm.wait_for_ssh()
         print("ssh available")
+        res = vm.ssh_cmd_sh("insmod $MODULE_DRIVERS_DIR/virtio/virtio_mmio.ko.xz")
+        assert res.returncode == 0
+        # assert that vritio_mmio is now loaded
         res = vm.ssh_cmd(["lsmod"])
         assert res.stdout
         assert res.stdout.find("virtio_mmio") >= 0

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -1,9 +1,9 @@
 import conftest
+from multiprocessing import Process
 
 
 def test_this_test(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
-        print("wait for ssh")
         vm.wait_for_ssh()
         print("ssh available")
         res = vm.ssh_cmd_sh("insmod $MODULE_DRIVERS_DIR/virtio/virtio_mmio.ko.xz")
@@ -14,12 +14,25 @@ def test_this_test(helpers: conftest.Helpers) -> None:
         assert res.stdout.find("virtio_mmio") >= 0
 
 
-# def test_virtio_device_space(helpers: conftest.Helpers) -> None:
-#     with helpers.spawn_qemu(helpers.notos_image()) as vm:
-#         print("wait for ssh")
-#         vm.wait_for_ssh()
-#         print("ssh available")
-#         vm.attach()
-#         res = vm.ssh_cmd(["insmod", "virtio_mmio"])
-#         print("stdout:\n", res.stdout)
-#         print("stderr:\n", res.stderr)
+def test_virtio_device_space(helpers: conftest.Helpers) -> None:
+    with helpers.spawn_qemu(helpers.notos_image()) as vm:
+        vmsh = Process(target=helpers.run_vmsh_command, args=(["attach", str(vm.pid)],))
+        vmsh.start()
+        vm.wait_for_ssh()
+        print("ssh available")
+
+        mmio_config = "0x1000@0xd0000000:5"
+        res = vm.ssh_cmd_sh(
+            f"insmod $MODULE_DRIVERS_DIR/virtio/virtio_mmio.ko.xz device={mmio_config}"
+        )
+        print("stdout:\n", res.stdout)
+        print("stderr:\n", res.stderr)
+
+        res = vm.ssh_cmd(["dmesg"])
+        print("stdout:\n", res.stdout)
+
+        vmsh.kill()
+        vmsh.join(10)
+        vmsh.terminate()
+
+        assert res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -6,8 +6,17 @@ def test_this_test(helpers: conftest.Helpers) -> None:
         print("wait for ssh")
         vm.wait_for_ssh()
         print("ssh available")
-        res = vm.ssh_cmd(["ls", "-lah", "/"])
-        print("stdout:\n", res.stdout)
-        # helpers.run_vmsh_command(
-        # ["fd_transfer1", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
-        # )
+        res = vm.ssh_cmd(["lsmod"])
+        assert res.stdout
+        assert res.stdout.find("virtio_mmio") >= 0
+
+
+# def test_virtio_device_space(helpers: conftest.Helpers) -> None:
+#     with helpers.spawn_qemu(helpers.notos_image()) as vm:
+#         print("wait for ssh")
+#         vm.wait_for_ssh()
+#         print("ssh available")
+#         vm.attach()
+#         res = vm.ssh_cmd(["insmod", "virtio_mmio"])
+#         print("stdout:\n", res.stdout)
+#         print("stderr:\n", res.stderr)


### PR DESCRIPTION
add irqfd and write test which loads the guest device driver and monitors dmesg for certain errros

Note: adds VIRTIO_MMIO_CMDLINE_DEVICES y to not-os kernel, so you better have a working nix cache because this will trigger a kernel build by nix

