### PR TITLE
Feature/parallel tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ fmt:
 
 test:
   cargo test
-  pytest -s tests
+  pytest -n $(nproc --ignore=2) -s tests
 
 clone-linux:
   [[ -d {{linux_dir}} ]] || \

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ let
 
   pythonEnv = (pkgs.python3.withPackages (ps: [
     ps.pytest
+    ps.pytest-xdist
     ps.pyelftools
 
     # linting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from typing import Iterator, List, Type
 
 import pytest
 from qemu import QemuVm, VmImage, spawn_qemu
-from root import TEST_ROOT
+from root import TEST_ROOT, PROJECT_ROOT
 
 sys.path.append(str(TEST_ROOT.parent))
 
@@ -20,8 +20,8 @@ build_artifacts = Path("/dev/null")  # folder with cargo-built executables
 
 
 def cargo_build() -> Path:
-    subprocess.run(["cargo", "build"])
-    return Path("target/debug")
+    subprocess.run(["cargo", "build"], cwd=PROJECT_ROOT)
+    return PROJECT_ROOT.joinpath("target", "debug")
 
 
 def rootfs_image(image: Path) -> VmImage:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,13 @@ from root import TEST_ROOT
 
 sys.path.append(str(TEST_ROOT.parent))
 
+build_artifacts = Path("/dev/null")  # folder with cargo-built executables
+
+
+def cargo_build() -> Path:
+    subprocess.run(["cargo", "build"])
+    return Path("target/debug")
+
 
 def rootfs_image(image: Path) -> VmImage:
     result = subprocess.run(
@@ -49,23 +56,16 @@ def ensure_debugfs_access() -> Iterator[None]:
         yield
 
 
-# cargo_options: additional args to pass to cargo. Example: "--bin test_ioctls"
-# to run a non-default binary
-def run_vmsh_command(args: List[str], cargo_options: List[str] = []) -> None:
+def run_vmsh_command(args: List[str], cargo_executable: str = "vmsh") -> None:
     if not os.path.isdir("/sys/module/kheaders"):
         subprocess.run(["sudo", "modprobe", "kheaders"])
     uid = os.getuid()
     gid = os.getuid()
     groups = ",".join(map(str, os.getgroups()))
     with ensure_debugfs_access():
-        cargoArgs = [
-            "cargo",
-            "run",
-        ]
-        cargoArgs += cargo_options
-        cargoArgs += ["--"]
-        cargoArgs += args
-        cargoCmd = " ".join(map(quote, cargoArgs))
+        cmd = [str(os.path.join(build_artifacts, cargo_executable))]
+        cmd += args
+        cmd_quoted = " ".join(map(quote, cmd))
 
         cmd = [
             "sudo",
@@ -81,7 +81,7 @@ def run_vmsh_command(args: List[str], cargo_options: List[str] = []) -> None:
             "--addamb=cap_sys_ptrace",
             "--",
             "-c",
-            cargoCmd,
+            cmd_quoted,
         ]
         print("$ " + " ".join(map(quote, cmd)))
         subprocess.run(cmd, check=True)
@@ -97,8 +97,8 @@ class Helpers:
         return rootfs_image(TEST_ROOT.joinpath("../nix/not-os-image.nix"))
 
     @staticmethod
-    def run_vmsh_command(args: List[str], cargo_options: List[str] = []) -> None:
-        return run_vmsh_command(args, cargo_options)
+    def run_vmsh_command(args: List[str], cargo_executable: str = "vmsh") -> None:
+        return run_vmsh_command(args, cargo_executable=cargo_executable)
 
     @staticmethod
     def spawn_qemu(image: VmImage) -> "contextlib._GeneratorContextManager[QemuVm]":
@@ -108,3 +108,6 @@ class Helpers:
 @pytest.fixture
 def helpers() -> Type[Helpers]:
     return Helpers
+
+
+build_artifacts = cargo_build()

--- a/tests/root.py
+++ b/tests/root.py
@@ -3,3 +3,4 @@
 from pathlib import Path
 
 TEST_ROOT = Path(__file__).parent.resolve()
+PROJECT_ROOT = TEST_ROOT.parent

--- a/tests/test_ioctl_alloc_mem.py
+++ b/tests/test_ioctl_alloc_mem.py
@@ -4,5 +4,5 @@ import conftest
 def test_ioctl_injection(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
-            ["alloc_mem", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+            ["alloc_mem", str(vm.pid)], cargo_executable="test_ioctls"
         )

--- a/tests/test_ioctl_guest_add_mem.py
+++ b/tests/test_ioctl_guest_add_mem.py
@@ -4,7 +4,7 @@ import conftest
 def test_ioctl_guest_add_mem(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
-            ["guest_add_mem", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+            ["guest_add_mem", str(vm.pid)], cargo_executable="test_ioctls"
         )
 
 
@@ -13,5 +13,5 @@ def test_ioctl_guest_add_mem_get_maps(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
             ["guest_add_mem_get_maps", str(vm.pid)],
-            cargo_options=["--bin", "test_ioctls"],
+            cargo_executable="test_ioctls",
         )

--- a/tests/test_ioctl_injection.py
+++ b/tests/test_ioctl_injection.py
@@ -4,5 +4,5 @@ import conftest
 def test_ioctl_injection(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
-            ["inject", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+            ["inject", str(vm.pid)], cargo_executable="test_ioctls"
         )

--- a/tests/test_ioeventfd.py
+++ b/tests/test_ioeventfd.py
@@ -4,12 +4,12 @@ import conftest
 def test_fd_transfer1(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
-            ["fd_transfer1", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+            ["fd_transfer1", str(vm.pid)], cargo_executable="test_ioctls"
         )
 
 
 def test_fd_transfer2(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
         helpers.run_vmsh_command(
-            ["fd_transfer2", str(vm.pid)], cargo_options=["--bin", "test_ioctls"]
+            ["fd_transfer2", str(vm.pid)], cargo_executable="test_ioctls"
         )


### PR DESCRIPTION
With warm caches test time is reduced from ~29s to 9s. Tests don't run `cargo run` but the executable `./target/...` directly. 