### PR TITLE
fix failing test: replace /tmp/foo by /dev/null

### DIFF
--- a/src/attach.rs
+++ b/src/attach.rs
@@ -18,7 +18,7 @@ pub fn attach(opts: &InspectOptions) -> Result<()> {
     ));
     vm.stop()?;
 
-    let device = try_with!(Device::new(&vm.clone()), "cannot create vm");
+    let device = try_with!(Device::new(&vm), "cannot create vm");
     vm.resume()?;
     device.create();
     device.create();

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -103,7 +103,7 @@ impl Device {
 
         let args = BlockArgs {
             common,
-            file_path: PathBuf::from("/tmp/foobar"),
+            file_path: PathBuf::from("/dev/null"),
             read_only: false,
             root_device: true,
             advertise_flush: true,

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -33,6 +33,7 @@ def test_virtio_device_space(helpers: conftest.Helpers) -> None:
 
         vmsh.kill()
         vmsh.join(10)
-        vmsh.terminate()
+        if vmsh.exitcode is None:
+            vmsh.terminate()
 
         assert res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0


### PR DESCRIPTION
also: fix vmsh.terminate() and a clippy warning