### PR TITLE
#85 clone: fix failing test: replace /tmp/foo by /dev/null

### DIFF
--- a/src/attach.rs
+++ b/src/attach.rs
@@ -18,7 +18,7 @@ pub fn attach(opts: &InspectOptions) -> Result<()> {
     ));
     vm.stop()?;
 
-    let device = try_with!(Device::new(&vm.clone()), "cannot create vm");
+    let device = try_with!(Device::new(&vm), "cannot create vm");
     vm.resume()?;
     device.create();
     device.create();

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -103,7 +103,7 @@ impl Device {
 
         let args = BlockArgs {
             common,
-            file_path: PathBuf::from("/tmp/foobar"),
+            file_path: PathBuf::from("/dev/null"),
             read_only: false,
             root_device: true,
             advertise_flush: true,

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -39,6 +39,7 @@ def test_virtio_device_space(helpers: conftest.Helpers) -> None:
 
         vmsh.kill()
         vmsh.join(10)
-        vmsh.terminate()
+        if vmsh.exitcode is None:
+            vmsh.terminate()
 
         assert res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -1,5 +1,4 @@
 import conftest
-from multiprocessing import Process
 import subprocess
 
 
@@ -19,48 +18,29 @@ def test_loading_virtio_mmio(helpers: conftest.Helpers) -> None:
 
 def test_virtio_device_space(helpers: conftest.Helpers) -> None:
     with helpers.spawn_qemu(helpers.notos_image()) as vm:
-        vmsh = Process(target=helpers.run_vmsh_command, args=(["attach", str(vm.pid)],))
-        vmsh.start()
-        vm.wait_for_ssh()
-        print("ssh available")
+        vmsh = helpers.spawn_vmsh_command(["attach", str(vm.pid)])
+        try:
+            vm.wait_for_ssh()
+            print("ssh available")
 
-        mmio_config = "0x1000@0xd0000000:5"
-        res = vm.ssh_cmd(
-            [
-                "insmod",
-                "/run/current-system/sw/lib/modules/virtio/virtio_mmio.ko",
-                f"device={mmio_config}",
-            ]
-        )
-        print("stdout:\n", res.stdout)
-        print("stderr:\n", res.stderr)
+            mmio_config = "0x1000@0xd0000000:5"
+            res = vm.ssh_cmd(
+                [
+                    "insmod",
+                    "/run/current-system/sw/lib/modules/virtio/virtio_mmio.ko",
+                    f"device={mmio_config}",
+                ]
+            )
+            print("stdout:\n", res.stdout)
+            print("stderr:\n", res.stderr)
 
-        res = vm.ssh_cmd(["dmesg"])
-        print("stdout:\n", res.stdout)
+            res = vm.ssh_cmd(["dmesg"])
+            print("stdout:\n", res.stdout)
 
-        print("multiprocessing pid: ", vmsh.pid)
-
-        # python sucks
-        print(
-            "kill children: ",
-            # The following runs do not kill children (daemonization?) but lead
-            # to tests appearing to terminate in a shell - but build CI will
-            # never terminate because it sees not all processes have
-            # terminated. See yourself how `ps aux | grep vmsh | wc -l`
-            # measures increasing numbers of vmsh processes before and after
-            # running test_virtio_blk.py when using on of the following:
-            #
-            # subprocess.run(["sudo", "pkill", "-P", f"{vmsh.pid}"], check=True),
-            # subprocess.run(["sh", "-c", f"pkill -P {vmsh.pid}"], check=True),
-            # (vmsh.kill() doesn't work either)
-            #
-            # The following magically removes all children though.
-            subprocess.run(["sudo", "su", "-c", f"pkill -P {vmsh.pid}"], check=True),
-        )
-        print("kill: ", subprocess.run(["kill", f"{vmsh.pid}"]))
-        vmsh.join(10)
-        if vmsh.exitcode is None:
-            print("termination needed ERROR")
-            # vmsh.terminate()
-
-        assert res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0
+            assert (
+                res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0
+            )
+        finally:
+            # we cannot kill sudo, but we can stop vmsh as it drops privileges to our user
+            subprocess.run(["pkill", "--parent", str(vmsh.pid)])
+            vmsh.wait()

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -51,7 +51,7 @@ def test_virtio_device_space(helpers: conftest.Helpers) -> None:
             # running test_virtio_blk.py when using on of the following:
             #
             # subprocess.run(["sudo", "pkill", "-P", f"{vmsh.pid}"], check=True),
-            # subprocess.run(["su", "-c", f"pkill -P {vmsh.pid}"], check=True),
+            # subprocess.run(["sh", "-c", f"pkill -P {vmsh.pid}"], check=True),
             # (vmsh.kill() doesn't work either)
             #
             # The following magically removes all children though.


### PR DESCRIPTION
#85 was never cherry picked into #83.

~~For clarification: /tmp/foo seems to exist on some drone machines, but if the test is run on one which doesn't have it, the test failed. This is fixed with this patch.~~
My new theory is that tests succeeded sometimes due to a race condition: if the test vm comes online faster than vmsh is built, vmsh is never run and /tmp/foobar never accessed. I will fix this race in another PR.

also: fix vmsh.terminate() and a clippy warning

