### PR TITLE
feature/blkdev

### DIFF
--- a/src/attach.rs
+++ b/src/attach.rs
@@ -41,7 +41,7 @@ pub fn attach(opts: &AttachOptions) -> Result<()> {
     let mut event_manager = try_with!(SubscriberEventManager::new(), "cannot create event manager");
     // TODO add subscriber (wrapped_exit_handler) and stuff?
 
-    // instanciate blkdev
+    // instantiate blkdev
     let device = try_with!(
         Device::new(&vm, &mut event_manager, &opts.backing),
         "cannot create vm"

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -59,8 +59,6 @@ pub fn attach(opts: &AttachOptions) -> Result<()> {
     info!("blkdev queue ready.");
     vm.resume()?;
 
-    //device.run_event_loop();
-
     info!("pause");
     nix::unistd::pause();
     let _err = child.join();
@@ -70,17 +68,17 @@ pub fn attach(opts: &AttachOptions) -> Result<()> {
 fn event_thread(mut event_mgr: SubscriberEventManager) {
     thread::spawn(move || loop {
         match event_mgr.run() {
-            Ok(_) => (),
+            Ok(nr) => log::debug!("EventManager {} events", nr),
             Err(e) => log::warn!("Failed to handle events: {:?}", e),
         }
         // TODO if !self.exit_handler.keep_running() { break; }
     });
 }
 
-fn exit_condition(_blkdev: &Arc<Mutex<Block>>) -> Result<bool> {
-    Ok(false)
-    //let blkdev = &try_with!(blkdev.lock(), "cannot get blkdev lock");
-    //Ok(blkdev.selected_queue().map(|q| q.ready).unwrap())
+fn exit_condition(blkdev: &Arc<Mutex<Block>>) -> Result<bool> {
+    //Ok(false)
+    let blkdev = &try_with!(blkdev.lock(), "cannot get blkdev lock");
+    Ok(blkdev.selected_queue().map(|q| q.ready).unwrap())
 }
 
 fn blkdev_monitor_thread(device: &Device) -> JoinHandle<()> {

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -145,8 +145,7 @@ fn run_kvm_wrapped(vm: &Arc<Hypervisor>, device: &Device) -> Result<()> {
                 }
             }
         }
-
-        Ok(())
+        //Ok(())
     })?;
     Ok(())
 }

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -248,7 +248,7 @@ fn subtest(name: &str) -> App {
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
 
     let app = App::new("test_ioctls")
         .about("Something between integration and unit test to be used by pytest.")

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -1,4 +1,5 @@
 use clap::{value_t, App, Arg, SubCommand};
+use std::sync::Mutex;
 use kvm_bindings as kvmb;
 use nix::unistd::Pid;
 use simple_error::{bail, try_with};
@@ -199,7 +200,10 @@ fn guest_ioeventfd(pid: Pid) -> Result<()> {
 
 fn guest_kvm_exits(pid: Pid) -> Result<()> {
     let vm = try_with!(get_hypervisor(pid), "cannot get vms for process {}", pid);
-    vm.kvmrun_wrapped(|wrapper: &mut KvmRunWrapper| {
+    //vm.kvmrun_wrapped(|wrapper: &mut KvmRunWrapper| {
+    vm.kvmrun_wrapped(|wrapper_r: &Mutex<Option<KvmRunWrapper>>| {
+        let mut wrapper_go = wrapper_r.lock().unwrap();
+        let wrapper = wrapper_go.as_mut().unwrap();
         let value: [u8; 2] = 0xDEADu16.to_ne_bytes();
         println!("attached");
 

--- a/src/bin/test_ioctls.rs
+++ b/src/bin/test_ioctls.rs
@@ -1,9 +1,9 @@
 use clap::{value_t, App, Arg, SubCommand};
-use std::sync::Mutex;
 use kvm_bindings as kvmb;
 use nix::unistd::Pid;
 use simple_error::{bail, try_with};
 use std::os::unix::io::AsRawFd;
+use std::sync::Mutex;
 use std::time::Duration;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 use vmsh::kvm::hypervisor::get_hypervisor;
@@ -200,7 +200,6 @@ fn guest_ioeventfd(pid: Pid) -> Result<()> {
 
 fn guest_kvm_exits(pid: Pid) -> Result<()> {
     let vm = try_with!(get_hypervisor(pid), "cannot get vms for process {}", pid);
-    //vm.kvmrun_wrapped(|wrapper: &mut KvmRunWrapper| {
     vm.kvmrun_wrapped(|wrapper_r: &Mutex<Option<KvmRunWrapper>>| {
         let mut wrapper_go = wrapper_r.lock().unwrap();
         let wrapper = wrapper_go.as_mut().unwrap();

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -28,6 +28,9 @@ const MEM_32BIT_GAP_SIZE: u64 = 768 << 20;
 /// The start of the memory area reserved for MMIO devices.
 pub const MMIO_MEM_START: u64 = FIRST_ADDR_PAST_32BITS - MEM_32BIT_GAP_SIZE;
 
+/// max mem space per device
+pub const DEVICE_MAX_MEM: u64 = 0x1000;
+
 pub type Block = block::Block<Arc<GuestMemoryMmap>>;
 
 fn convert(mappings: &[Mapping]) -> Result<GuestMemoryMmap> {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,7 @@
 pub mod mmio;
 mod virtio;
 
+use crate::attach::SubscriberEventManager;
 use crate::device::mmio::{IoPirate, MmioDeviceSpace};
 use crate::device::virtio::block::{self, BlockArgs};
 use crate::device::virtio::{CommonArgs, MmioConfig};
@@ -9,7 +10,7 @@ use crate::result::Result;
 use crate::tracer::proc::Mapping;
 use event_manager::{EventManager, MutEventSubscriber};
 use log::*;
-use simple_error::{bail, try_with};
+use simple_error::{bail, map_err_with, try_with};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use vm_device::bus::{MmioAddress, MmioRange};
@@ -79,7 +80,11 @@ pub struct Device {
 }
 
 impl Device {
-    pub fn new(vmm: &Arc<Hypervisor>, backing: &Path) -> Result<Device> {
+    pub fn new(
+        vmm: &Arc<Hypervisor>,
+        event_mgr: &mut SubscriberEventManager,
+        backing: &Path,
+    ) -> Result<Device> {
         let guest_memory = try_with!(vmm.get_maps(), "cannot get guests memory");
         let mem: Arc<GuestMemoryMmap> = Arc::new(try_with!(
             convert(&guest_memory),
@@ -98,16 +103,10 @@ impl Device {
         let guard = device_manager.lock().unwrap();
         guard.mmio_device(MmioAddress(MMIO_MEM_START));
 
-        let mut event_manager = try_with!(
-            EventManager::<Arc<Mutex<dyn MutEventSubscriber + Send>>>::new(),
-            "cannot create event manager"
-        );
-        // TODO add subscriber (wrapped_exit_handler) and stuff?
-
         let common = CommonArgs {
             mem,
             vmm: vmm.clone(),
-            event_mgr: &mut event_manager,
+            event_mgr,
             mmio_mgr: guard,
             mmio_cfg,
         };

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -8,9 +8,8 @@ use crate::device::virtio::{CommonArgs, MmioConfig};
 use crate::kvm::hypervisor::{Hypervisor, VmMem};
 use crate::result::Result;
 use crate::tracer::proc::Mapping;
-use event_manager::{EventManager, MutEventSubscriber};
 use log::*;
-use simple_error::{bail, map_err_with, try_with};
+use simple_error::{bail, try_with};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use vm_device::bus::{MmioAddress, MmioRange};
@@ -69,7 +68,6 @@ fn convert(mappings: &[Mapping]) -> Result<GuestMemoryMmap> {
     ))
 }
 
-#[allow(dead_code)] // FIXME
 pub struct Device {
     vmm: Arc<Hypervisor>,
     pub blkdev: Arc<Mutex<Block>>,

--- a/src/device/virtio/block/device.rs
+++ b/src/device/virtio/block/device.rs
@@ -17,7 +17,7 @@ use vm_memory::GuestAddressSpace;
 use vm_virtio::block::stdio_executor::StdIoBackend;
 use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioMmioDevice};
 use vm_virtio::Queue;
-use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+use vmm_sys_util::eventfd::EventFd;
 
 use crate::device::virtio::block::{BLOCK_DEVICE_ID, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO};
 use crate::device::virtio::features::{
@@ -33,7 +33,7 @@ use super::queue_handler::QueueHandler;
 use super::{build_config_space, BlockArgs, Error, Result};
 use crate::tracer::inject_syscall;
 use crate::tracer::wrap_syscall::KvmRunWrapper;
-use simple_error::{map_err_with, simple_error, try_with};
+use simple_error::map_err_with;
 
 // This Block device can only use the MMIO transport for now, but we plan to reuse large parts of
 // the functionality when we implement virtio PCI as well, for example by having a base generic
@@ -195,7 +195,7 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Bloc
         //         0u32,
         //     )
         //     .map_err(Error::RegisterIoevent)?;
-        let mut ioeventfd;
+        let ioeventfd;
         {
             let mut wrapper_go =
                 map_err_with!(self.vmm.wrapper.lock(), "cannot obtain wrapper mutex")

--- a/src/device/virtio/block/device.rs
+++ b/src/device/virtio/block/device.rs
@@ -227,7 +227,10 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Bloc
             .call_blocking(move |mgr| -> EvmgrResult<SubscriberId> {
                 Ok(mgr.add_subscriber(handler))
             })
-            .map_err(Error::Endpoint)?;
+            .map_err(|e| {
+                log::warn!("{}", e);
+                Error::Endpoint(e)
+            })?;
 
         self.virtio_cfg.device_activated = true;
 

--- a/src/device/virtio/block/device.rs
+++ b/src/device/virtio/block/device.rs
@@ -77,13 +77,13 @@ where
         let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
 
         // Used to send notifications to the driver.
-        let irqfd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
-
-        // FIXME register irqfd on hypervisor
-        // args.common
-        //     .vm_fd
-        //     .register_irqfd(&irqfd, args.common.mmio_cfg.gsi)
-        //     .map_err(Error::RegisterIrqfd)?;
+        //let irqfd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+        log::debug!("register irqfd on gsi {}", args.common.mmio_cfg.gsi);
+        let irqfd = args
+            .common
+            .vmm
+            .irqfd(args.common.mmio_cfg.gsi)
+            .map_err(|e| Error::Simple(e))?;
 
         let mmio_cfg = args.common.mmio_cfg;
 

--- a/src/device/virtio/block/device.rs
+++ b/src/device/virtio/block/device.rs
@@ -31,9 +31,9 @@ use crate::kvm::hypervisor::Hypervisor;
 use super::inorder_handler::InOrderQueueHandler;
 use super::queue_handler::QueueHandler;
 use super::{build_config_space, BlockArgs, Error, Result};
-use crate::tracer::wrap_syscall::KvmRunWrapper;
 use crate::tracer::inject_syscall;
-use simple_error::{try_with, simple_error, map_err_with};
+use crate::tracer::wrap_syscall::KvmRunWrapper;
+use simple_error::{map_err_with, simple_error, try_with};
 
 // This Block device can only use the MMIO transport for now, but we plan to reuse large parts of
 // the functionality when we implement virtio PCI as well, for example by having a base generic
@@ -43,7 +43,6 @@ pub struct Block<M: GuestAddressSpace> {
     pub mmio_cfg: MmioConfig,
     endpoint: RemoteEndpoint<Arc<Mutex<dyn MutEventSubscriber + Send>>>,
     vmm: Arc<Hypervisor>,
-    pub tracer: Option<KvmRunWrapper>,
     irqfd: Arc<EventFd>,
     file_path: PathBuf,
     read_only: bool,
@@ -101,7 +100,6 @@ where
             file_path: args.file_path,
             read_only: args.read_only,
             _root_device: args.root_device,
-            tracer: None,
         }));
 
         // Register the device on the MMIO bus.
@@ -166,7 +164,8 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> BorrowMut<VirtioConfig<M>> f
 impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Block<M> {
     type E = Error;
 
-    /// make sure to set self.tracer to Some() before activating
+    /// make sure to set self.vmm.wrapper to Some() before activating. Typically this is done by
+    /// activating during vmm.kvmrun_wrapped()
     fn activate(&mut self) -> Result<()> {
         if self.virtio_cfg.device_activated {
             return Err(Error::AlreadyActivated);
@@ -199,26 +198,34 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Bloc
         //     .map_err(Error::RegisterIoevent)?;
         {
             //let mut wrapper_go = self.vmm.wrapper.lock().map_err(|e| simple_error!("cannot obtain wrapper mutex, {}", e)).map_err(|e| Error::Simple(e))?;
-            let mut wrapper_go = map_err_with!(self.vmm.wrapper.lock(), "cannot obtain wrapper mutex").map_err(|e| Error::Simple(e))?;
+            let mut wrapper_go =
+                map_err_with!(self.vmm.wrapper.lock(), "cannot obtain wrapper mutex")
+                    .map_err(|e| Error::Simple(e))?;
             let wrapper = wrapper_go.take().unwrap();
-            let mut tracee = self.vmm.tracee_write_guard().map_err(|e| Error::Simple(e))?;
-            
+            let mut tracee = self
+                .vmm
+                .tracee_write_guard()
+                .map_err(|e| Error::Simple(e))?;
+
             // wrapper -> injector
             let err = "cannot re-attach injector after having detached it favour of KvmRunWrapper";
-            let injector = map_err_with!(inject_syscall::from_tracer(
-                    wrapper.into_tracer().map_err(|e| Error::Simple(e))?
-            ), &err).map_err(|e| Error::Simple(e))?;
+            let injector = map_err_with!(
+                inject_syscall::from_tracer(wrapper.into_tracer().map_err(|e| Error::Simple(e))?),
+                &err
+            )
+            .map_err(|e| Error::Simple(e))?;
             map_err_with!(tracee.attach_to(injector), &err).map_err(|e| Error::Simple(e))?;
 
-            let _ptr = tracee.mmap(1);
+            let _ptr = tracee.mmap(1); // TODO
 
             // injector -> wrapper
             // we may unwrap because we just attached it.
             let injector = tracee.detach().unwrap();
-            let wrapper = KvmRunWrapper::from_tracer(inject_syscall::into_tracer(
-                injector,
-                self.vmm.vcpu_maps[0].clone(),
-            ).map_err(|e| Error::Simple(e))?).map_err(|e| Error::Simple(e))?;
+            let wrapper = KvmRunWrapper::from_tracer(
+                inject_syscall::into_tracer(injector, self.vmm.vcpu_maps[0].clone())
+                    .map_err(|e| Error::Simple(e))?,
+            )
+            .map_err(|e| Error::Simple(e))?;
             let _ = wrapper_go.replace(wrapper);
         }
         // self.vmm

--- a/src/device/virtio/block/mod.rs
+++ b/src/device/virtio/block/mod.rs
@@ -16,6 +16,7 @@ use vm_virtio::block::stdio_executor;
 use vmm_sys_util::errno;
 
 use crate::device::virtio::CommonArgs;
+use simple_error::SimpleError;
 
 pub use device::Block;
 
@@ -48,6 +49,7 @@ pub enum Error {
     #[allow(dead_code)] // FIXME
     RegisterIrqfd(errno::Error),
     Seek(io::Error),
+    Simple(SimpleError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/device/virtio/mod.rs
+++ b/src/device/virtio/mod.rs
@@ -9,12 +9,10 @@ pub mod block;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 
+use crate::kvm::hypervisor::Hypervisor;
 use event_manager::{EventManager, MutEventSubscriber};
 use log::error;
-//use kvm_ioctls::VmFd; FIXME remove
-use crate::kvm::hypervisor::Hypervisor;
 
-//use linux_loader::cmdline::Cmdline; FIXME remove
 use vm_device::bus::MmioRange;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -37,7 +35,6 @@ const VIRTIO_MMIO_INT_VRING: u8 = 0x01;
 
 // The driver will write to the register at this offset in the MMIO region to notify the device
 // about available queue events.
-#[allow(dead_code)] // FIXME
 const VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET: u64 = 0x50;
 
 // TODO: Make configurable for each device maybe?
@@ -56,7 +53,6 @@ pub struct CommonArgs<'a, M, B> {
     // The objects used for guest memory accesses and other operations.
     pub mem: M,
     // Used by the devices to register ioevents and irqfds.
-    //pub vm_fd: Arc<VmFd>, FIXME remove
     pub vmm: Arc<Hypervisor>,
     // Mutable handle to the event manager the device is supposed to register with. There could be
     // more if we decide to use more than just one thread for device model emulation.
@@ -70,7 +66,6 @@ pub struct CommonArgs<'a, M, B> {
     // required arguments (i.e. for virtio over MMIO discovery). This means we need to create
     // the devices before loading he kernel cmdline into memory, but that's not a significant
     // limitation.
-    //pub kernel_cmdline: &'a mut Cmdline, FIXME remove
 }
 
 /// Simple trait to model the operation of signalling the driver about used events

--- a/src/kvm/hypervisor.rs
+++ b/src/kvm/hypervisor.rs
@@ -207,7 +207,7 @@ impl Hypervisor {
     }
 
     pub fn tracee_write_guard(&self) -> Result<RwLockWriteGuard<Tracee>> {
-        let mut twg: RwLockWriteGuard<Tracee> = try_with!(
+        let twg: RwLockWriteGuard<Tracee> = try_with!(
             self.tracee.write(),
             "cannot obtain tracee read lock: poinsoned"
         );

--- a/src/tracer/wrap_syscall.rs
+++ b/src/tracer/wrap_syscall.rs
@@ -215,7 +215,7 @@ impl KvmRunWrapper {
     }
 
     /// Should be called before or during dropping a KvmRunWrapper
-    pub fn prepare_detach(&mut self) -> Result<()> {
+    fn prepare_detach(&mut self) -> Result<()> {
         for thread in &self.threads {
             try_with!(
                 thread.prepare_detach(),


### PR DESCRIPTION
- fill all the missing parts in device/
- start event loop thread
- attach ioeventfd and irqfd
- fix vmsh deadlock on Block.activate()

In theory everything should be implemented now for a working prototype block device. Device init and blockdevice activation complete. Vmsh segfaults though with virtqueue accesses (reads prob. go to wrong address space). Therefore the tests stop after queue_ready.