### PR TITLE
Feature/virtqueues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ source = "git+https://github.com/rust-vmm/vm-device?rev=989c315712b80a538331fe05
 [[package]]
 name = "vm-memory"
 version = "0.5.0"
+source = "git+https://github.com/pogobanane/vm-memory.git?rev=d4885a850386c630f4cb254645791a1e3d3a8d90#d4885a850386c630f4cb254645791a1e3d3a8d90"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,10 +383,10 @@ source = "git+https://github.com/rust-vmm/vm-device?rev=989c315712b80a538331fe05
 [[package]]
 name = "vm-memory"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625f401b1b8b3ac3d43f53903cd138cfe840bd985f8581e553027b31d2bb8ae8"
 dependencies = [
  "libc",
+ "log",
+ "nix",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,5 @@ vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 log = "0.4.6"
 
 [patch.crates-io]
-# update rev before enabling:
-# vm-memory = { git = "https://github.com/pogobanane/vm-memory.git", rev = "a7d4e5e19d94f5f4b9771f12f2c7ef0794abe9e8", features = ["backend-mmap"] }
-vm-memory = { path = "../vm-memory", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/pogobanane/vm-memory.git", rev = "d4885a850386c630f4cb254645791a1e3d3a8d90", features = ["backend-mmap"] }
+# vm-memory = { path = "../vm-memory", features = ["backend-mmap"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,8 @@ event-manager = { version = "0.2.1", features = ["remote_endpoint"] }
 vmm-sys-util = "0.8.0" # only for its ::eventfd::EventFd
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 log = "0.4.6"
+
+[patch.crates-io]
+# update rev before enabling:
+# vm-memory = { git = "https://github.com/pogobanane/vm-memory.git", rev = "a7d4e5e19d94f5f4b9771f12f2c7ef0794abe9e8", features = ["backend-mmap"] }
+vm-memory = { path = "../vm-memory", features = ["backend-mmap"] }

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ qemu EXTRA_CMDLINE="nokalsr": build-linux nixos-image
     -append "root=/dev/sda console=ttyS0 {{EXTRA_CMDLINE}}" \
     -net nic,netdev=user.0,model=virtio \
     -m 512M \
-    -netdev user,id=user.0,hostfwd=tcp:127.0.0.1:{{qemu_ssh_port}}-:21 \
+    -netdev user,id=user.0,hostfwd=tcp:127.0.0.1:{{qemu_ssh_port}}-:22 \
     -cpu host \
     -virtfs local,path={{invocation_directory()}}/..,security_model=none,mount_tag=home \
     -virtfs local,path={{linux_dir}},security_model=none,mount_tag=linux \

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -76,9 +76,9 @@ fn event_thread(mut event_mgr: SubscriberEventManager) {
 }
 
 fn exit_condition(blkdev: &Arc<Mutex<Block>>) -> Result<bool> {
-    //Ok(false)
-    let blkdev = &try_with!(blkdev.lock(), "cannot get blkdev lock");
-    Ok(blkdev.selected_queue().map(|q| q.ready).unwrap())
+    Ok(false)
+    //let blkdev = &try_with!(blkdev.lock(), "cannot get blkdev lock");
+    //Ok(blkdev.selected_queue().map(|q| q.ready).unwrap())
 }
 
 fn blkdev_monitor_thread(device: &Device) -> JoinHandle<()> {

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -75,8 +75,9 @@ fn event_thread(mut event_mgr: SubscriberEventManager) {
     });
 }
 
-fn exit_condition(blkdev: &Arc<Mutex<Block>>) -> Result<bool> {
+fn exit_condition(_blkdev: &Arc<Mutex<Block>>) -> Result<bool> {
     Ok(false)
+    // TODO think of teardown
     //let blkdev = &try_with!(blkdev.lock(), "cannot get blkdev lock");
     //Ok(blkdev.selected_queue().map(|q| q.ready).unwrap())
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -19,6 +19,7 @@ use vm_memory::guest_memory::GuestAddress;
 use vm_memory::mmap::MmapRegion;
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{GuestMemoryMmap, GuestRegionMmap};
+use libc::pid_t;
 
 // Where BIOS/VGA magic would live on a real PC.
 #[allow(dead_code)] // FIXME
@@ -33,7 +34,7 @@ pub const DEVICE_MAX_MEM: u64 = 0x1000;
 
 pub type Block = block::Block<Arc<GuestMemoryMmap>>;
 
-fn convert(mappings: &[Mapping]) -> Result<GuestMemoryMmap> {
+fn convert(pid: pid_t, mappings: &[Mapping]) -> Result<GuestMemoryMmap> {
     let mut regions: Vec<Arc<GuestRegionMmap>> = vec![];
 
     for mapping in mappings {
@@ -51,7 +52,7 @@ fn convert(mappings: &[Mapping]) -> Result<GuestMemoryMmap> {
         );
 
         let guest_region_mmap = try_with!(
-            GuestRegionMmap::new(mmap_region, GuestAddress(mapping.phys_addr as u64)),
+            GuestRegionMmap::new(pid, mmap_region, GuestAddress(mapping.phys_addr as u64)),
             "cannot allocate guest region"
         );
 
@@ -63,7 +64,7 @@ fn convert(mappings: &[Mapping]) -> Result<GuestMemoryMmap> {
 
     // trows regions overlap error because start_addr (guest) is 0 for all regions.
     Ok(try_with!(
-        GuestMemoryMmap::from_arc_regions(regions),
+        GuestMemoryMmap::from_arc_regions(pid, regions),
         "GuestMemoryMmap error"
     ))
 }
@@ -85,7 +86,7 @@ impl Device {
     ) -> Result<Device> {
         let guest_memory = try_with!(vmm.get_maps(), "cannot get guests memory");
         let mem: Arc<GuestMemoryMmap> = Arc::new(try_with!(
-            convert(&guest_memory),
+            convert(vmm.pid.as_raw(), &guest_memory),
             "cannot convert Mapping to GuestMemoryMmap"
         ));
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -8,6 +8,7 @@ use crate::device::virtio::{CommonArgs, MmioConfig};
 use crate::kvm::hypervisor::{Hypervisor, VmMem};
 use crate::result::Result;
 use crate::tracer::proc::Mapping;
+use libc::pid_t;
 use log::*;
 use simple_error::{bail, try_with};
 use std::path::Path;
@@ -19,7 +20,6 @@ use vm_memory::guest_memory::GuestAddress;
 use vm_memory::mmap::MmapRegion;
 use vm_memory::GuestMemoryRegion;
 use vm_memory::{GuestMemoryMmap, GuestRegionMmap};
-use libc::pid_t;
 
 // Where BIOS/VGA magic would live on a real PC.
 #[allow(dead_code)] // FIXME

--- a/src/device/virtio/block/inorder_handler.rs
+++ b/src/device/virtio/block/inorder_handler.rs
@@ -50,7 +50,7 @@ where
     fn process_chain(&mut self, mut chain: DescriptorChain<M>) -> result::Result<(), Error> {
         let len;
 
-        log::warn!("process_chain");
+        log::trace!("process_chain");
         match Request::parse(&mut chain) {
             Ok(request) => {
                 let status = match self.disk.execute(chain.memory(), &request) {

--- a/src/device/virtio/block/inorder_handler.rs
+++ b/src/device/virtio/block/inorder_handler.rs
@@ -50,6 +50,7 @@ where
     fn process_chain(&mut self, mut chain: DescriptorChain<M>) -> result::Result<(), Error> {
         let len;
 
+        log::warn!("process_chain");
         match Request::parse(&mut chain) {
             Ok(request) => {
                 let status = match self.disk.execute(chain.memory(), &request) {

--- a/src/kvm/hypervisor.rs
+++ b/src/kvm/hypervisor.rs
@@ -2,18 +2,16 @@ use crate::tracer::inject_syscall;
 use kvm_bindings as kvmb;
 use libc::{c_int, c_void};
 use log::*;
-use nix::sys::uio::{process_vm_readv, process_vm_writev, IoVec, RemoteIoVec};
 use nix::unistd::Pid;
-use simple_error::{bail, try_with, simple_error};
+use simple_error::{bail, simple_error, try_with};
 use std::ffi::OsStr;
 use std::marker::PhantomData;
 use std::mem::size_of;
-use std::mem::MaybeUninit;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
-use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 use vm_memory::remote_mem;
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
 use crate::cpu;
 use crate::kvm::fd_transfer;
@@ -57,10 +55,10 @@ impl<T: Copy> Drop for HvMem<T> {
 
 impl<T: Copy> HvMem<T> {
     pub fn read(&self) -> Result<T> {
-        process_read(self.pid, self.ptr).map_err(|e| simple_error!("{}", e))
+        process_read(self.pid, self.ptr)
     }
     pub fn write(&self, val: &T) -> Result<()> {
-        process_write(self.pid, self.ptr, val).map_err(|e| simple_error!("{}", e))
+        process_write(self.pid, self.ptr, val)
     }
 }
 

--- a/src/kvm/hypervisor.rs
+++ b/src/kvm/hypervisor.rs
@@ -4,7 +4,7 @@ use libc::{c_int, c_void};
 use log::*;
 use nix::sys::uio::{process_vm_readv, process_vm_writev, IoVec, RemoteIoVec};
 use nix::unistd::Pid;
-use simple_error::{bail, try_with};
+use simple_error::{bail, try_with, simple_error};
 use std::ffi::OsStr;
 use std::marker::PhantomData;
 use std::mem::size_of;
@@ -13,6 +13,7 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::sync::{Arc, Mutex, RwLock, RwLockWriteGuard};
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+use vm_memory::remote_mem;
 
 use crate::cpu;
 use crate::kvm::fd_transfer;
@@ -23,66 +24,12 @@ use crate::result::Result;
 use crate::tracer::proc::{openpid, Mapping, PidHandle};
 use crate::tracer::wrap_syscall::KvmRunWrapper;
 
-/// # Safety
-///
-/// None. See safety chapter of `std::slice::from_raw_parts`.
-pub unsafe fn any_as_bytes<T: Sized>(p: &T) -> &[u8] {
-    std::slice::from_raw_parts((p as *const T) as *const u8, size_of::<T>())
-}
-
-/// read from a virtual addr of the hypervisor
 pub fn process_read<T: Sized + Copy>(pid: Pid, addr: *const c_void) -> Result<T> {
-    let len = size_of::<T>();
-    let mut t_mem = MaybeUninit::<T>::uninit();
-    let t_slice = unsafe { std::slice::from_raw_parts_mut(t_mem.as_mut_ptr() as *mut u8, len) };
-
-    let local_iovec = vec![IoVec::from_mut_slice(t_slice)];
-    let remote_iovec = vec![RemoteIoVec {
-        base: addr as usize,
-        len,
-    }];
-
-    let f = try_with!(
-        process_vm_readv(pid, local_iovec.as_slice(), remote_iovec.as_slice()),
-        "cannot read memory"
-    );
-    if f != len {
-        bail!(
-            "process_vm_readv read {} bytes when {} were expected",
-            f,
-            len
-        )
-    }
-
-    let t: T = unsafe { t_mem.assume_init() };
-    Ok(t)
+    remote_mem::process_read(pid, addr).map_err(|e| simple_error!("{}", e))
 }
 
-/// write to a virtual addr of the hypervisor
 pub fn process_write<T: Sized + Copy>(pid: Pid, addr: *mut c_void, val: &T) -> Result<()> {
-    let len = size_of::<T>();
-    // safe, because we won't need t_bytes for long
-    let t_bytes = unsafe { any_as_bytes(val) };
-
-    let local_iovec = vec![IoVec::from_slice(t_bytes)];
-    let remote_iovec = vec![RemoteIoVec {
-        base: addr as usize,
-        len,
-    }];
-
-    let f = try_with!(
-        process_vm_writev(pid, local_iovec.as_slice(), remote_iovec.as_slice()),
-        "cannot write memory"
-    );
-    if f != len {
-        bail!(
-            "process_vm_writev written {} bytes when {} were expected",
-            f,
-            len
-        )
-    }
-
-    Ok(())
+    remote_mem::process_write(pid, addr, val).map_err(|e| simple_error!("{}", e))
 }
 
 /// Hypervisor Memory
@@ -110,10 +57,10 @@ impl<T: Copy> Drop for HvMem<T> {
 
 impl<T: Copy> HvMem<T> {
     pub fn read(&self) -> Result<T> {
-        process_read(self.pid, self.ptr)
+        process_read(self.pid, self.ptr).map_err(|e| simple_error!("{}", e))
     }
     pub fn write(&self, val: &T) -> Result<()> {
-        process_write(self.pid, self.ptr, val)
+        process_write(self.pid, self.ptr, val).map_err(|e| simple_error!("{}", e))
     }
 }
 

--- a/src/tracer/wrap_syscall.rs
+++ b/src/tracer/wrap_syscall.rs
@@ -6,10 +6,7 @@ use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::Pid;
 use simple_error::bail;
 use simple_error::try_with;
-use simple_error::map_err_with;
-use simple_error::simple_error;
 use std::fmt;
-use vm_memory::remote_mem::{process_read, process_write};
 
 use crate::kvm::hypervisor;
 use crate::kvm::ioctls;
@@ -89,16 +86,16 @@ impl MmioRw {
         // may or may not perform vcpu_map size assertions.
         let mmio_ptr: *mut MmioRwRaw = unsafe { &mut ((*kvm_run_ptr).__bindgen_anon_1.mmio) };
         let data_ptr: *mut [u8; MMIO_RW_DATA_MAX] = unsafe { &mut ((*mmio_ptr).data) };
-        process_write(self.pid, data_ptr as *mut libc::c_void, &self.data).map_err(|e| simple_error!("{}", e))?;
+        hypervisor::process_write(self.pid, data_ptr as *mut libc::c_void, &self.data)?;
 
         // guess who will never know that this was a mmio read
         let is_totally_write = 1u8;
         let is_write_ptr: *mut u8 = unsafe { &mut ((*mmio_ptr).is_write) };
-        process_write(
+        hypervisor::process_write(
             self.pid,
             is_write_ptr as *mut libc::c_void,
             &is_totally_write,
-        ).map_err(|e| simple_error!("{}", e))?;
+        )?;
 
         Ok(())
     }
@@ -391,7 +388,7 @@ impl KvmRunWrapper {
         // fulfilled precondition: ioctl(KVM_RUN) just returned
         let map_ptr = thread.vcpu_map.start as *const kvm_bindings::kvm_run;
         let kvm_run: kvm_bindings::kvm_run =
-            process_read(pid, map_ptr as *const libc::c_void).map_err(|e| simple_error!("{}", e))?;
+            hypervisor::process_read(pid, map_ptr as *const libc::c_void)?;
         let mmio = MmioRw::from(&kvm_run, thread.ptthread.tid, thread.vcpu_map.clone());
 
         Ok(mmio)


### PR DESCRIPTION
Working proof of concept for blockdevice (`vmsh attach`). Data can be read and written. 

Known issues: 
- the device Err()s regularly because we dont track new qemu threads
- KvmRunWrapper busy polling is using 1 cpu