### PR TITLE
Feature/blkdev hvthreads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ source = "git+https://github.com/rust-vmm/vm-device?rev=989c315712b80a538331fe05
 [[package]]
 name = "vm-memory"
 version = "0.5.0"
-source = "git+https://github.com/pogobanane/vm-memory.git?rev=d4885a850386c630f4cb254645791a1e3d3a8d90#d4885a850386c630f4cb254645791a1e3d3a8d90"
+source = "git+https://github.com/pogobanane/vm-memory.git?rev=ecf1d8e0fd765759559c586d83760dfaf9812a8c#ecf1d8e0fd765759559c586d83760dfaf9812a8c"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 log = "0.4.6"
 
 [patch.crates-io]
-vm-memory = { git = "https://github.com/pogobanane/vm-memory.git", rev = "d4885a850386c630f4cb254645791a1e3d3a8d90", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/pogobanane/vm-memory.git", rev = "ecf1d8e0fd765759559c586d83760dfaf9812a8c", features = ["backend-mmap"] }
 # vm-memory = { path = "../vm-memory", features = ["backend-mmap"] }

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -68,7 +68,7 @@ pub fn attach(opts: &AttachOptions) -> Result<()> {
 fn event_thread(mut event_mgr: SubscriberEventManager) {
     thread::spawn(move || loop {
         match event_mgr.run() {
-            Ok(nr) => log::debug!("EventManager {} events", nr),
+            Ok(nr) => log::debug!("EventManager: processed {} events", nr),
             Err(e) => log::warn!("Failed to handle events: {:?}", e),
         }
         // TODO if !self.exit_handler.keep_running() { break; }

--- a/src/device/virtio/block/inorder_handler.rs
+++ b/src/device/virtio/block/inorder_handler.rs
@@ -53,6 +53,7 @@ where
         log::trace!("process_chain");
         match Request::parse(&mut chain) {
             Ok(request) => {
+                log::trace!("request: {:?}", request);
                 let status = match self.disk.execute(chain.memory(), &request) {
                     Ok(l) => {
                         // TODO: Using `saturating_add` until we consume the recent changes
@@ -91,6 +92,7 @@ where
             self.driver_notify.signal_used_queue(0);
         }
 
+        log::trace!("process_chain done");
         Ok(())
     }
 

--- a/src/device/virtio/mod.rs
+++ b/src/device/virtio/mod.rs
@@ -86,6 +86,7 @@ pub struct SingleFdSignalQueue {
 
 impl SignalUsedQueue for SingleFdSignalQueue {
     fn signal_used_queue(&self, _index: u16) {
+        log::debug!("irqfd << {}", _index);
         self.interrupt_status
             .fetch_or(VIRTIO_MMIO_INT_VRING, Ordering::SeqCst);
         if let Err(e) = self.irqfd.write(1) {

--- a/src/tracer/wrap_syscall.rs
+++ b/src/tracer/wrap_syscall.rs
@@ -339,7 +339,12 @@ impl KvmRunWrapper {
             .threads
             .iter()
             .position(|t| t.ptthread.tid == tid)
-            .expect("the programmer must not drop threads which are not present");
+            .unwrap_or_else(|| {
+                panic!(
+                    "BUG! must not drop threads which are not present (tid={})",
+                    tid
+                )
+            });
         // remove and shift others to left
         self.threads.remove(idx);
         // shift idx if it was shifted

--- a/tests/test_virtio_blk.py
+++ b/tests/test_virtio_blk.py
@@ -58,3 +58,11 @@ def test_virtio_device_space(helpers: conftest.Helpers) -> None:
                 )
                 > 0
             )
+
+            try:
+                vmsh.wait(timeout=20)
+            except Exception:
+                # vmsh did not crash unexpectedly within timeout. This is good.
+                ()
+            else:
+                assert 0 == "Vmsh did crash unexpectedly. This is bad."


### PR DESCRIPTION
- d9db7b8 is functionally the same as 8a8dd2694943dff3f87e0d24eeefa914862ceea4
- activates a new [vm-memory commit](https://github.com/pogobanane/vm-memory/commit/ecf1d8e0fd765759559c586d83760dfaf9812a8c)

About that commit:
Especially during heavy operations (`tail -c 8193 /dev/vda` or after `mount /dev/vda`) the driver often seized operation and did not even react to interrupts anymore. This could very well be caused by lacking atomicity of [store()](https://github.com/pogobanane/vm-memory/blob/ecf1d8e0fd765759559c586d83760dfaf9812a8c/src/mmap.rs#L467). After adding a barrier to process_write in the vm-memory commit, the issue was not reproducible anymore. 

Adding a printk into the drivers interrupt handler seems to have the same effect...