### PR TITLE
Fix cleanup from vmsh

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
             pkgs.cargo-deny
             pkgs.pre-commit
             pkgs.rls
-            pkgs.racer
+            pkgs.rustracer
             pkgs.git # needed for pre-commit install
             fenixPkgs.rust-analyzer
             pkgs.gdb

--- a/src/attach.rs
+++ b/src/attach.rs
@@ -96,6 +96,9 @@ pub fn attach(opts: &AttachOptions) -> Result<()> {
         }
     }
 
+    // MMIO exit handler thread took over pthread control
+    // We need ptrace the process again before we can finish.
+    vm.finish_thread_transfer()?;
     vm.resume()?;
 
     Ok(())

--- a/src/device/threads.rs
+++ b/src/device/threads.rs
@@ -208,13 +208,16 @@ fn mmio_exit_handler_thread(
 
             info!("mmio dev attached");
 
-            vm.kvmrun_wrapped(|wrapper_mo: &Mutex<Option<KvmRunWrapper>>| {
+            let res = vm.kvmrun_wrapped(|wrapper_mo: &Mutex<Option<KvmRunWrapper>>| {
                 // Signal that our blockdevice driver is ready now
                 handle_mmio_exits(wrapper_mo, &should_stop, &device, &device_ready)?;
 
                 Ok(())
-            })?;
-            Ok(())
+            });
+
+            // we need to return ptrace control before returning to the main thread
+            vm.prepare_thread_transfer()?;
+            res
         },
     );
 

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use log::{info, log_enabled, warn, Level};
 use nix::sys::signal::{kill, SIGTERM};
 use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
@@ -36,10 +37,11 @@ fn cleanup_stage1(ssh_args: &[String]) -> Result<()> {
 
 impl Drop for Stage1 {
     fn drop(&mut self) {
-        info!("start stage1 cleanup");
+        debug!("stage1 cleanup started");
         if let Err(e) = cleanup_stage1(&self.ssh_args) {
             warn!("could not cleanup stage1: {}", e);
         }
+        debug!("stage1 cleanup finished");
     }
 }
 

--- a/src/tracer/inject_syscall.rs
+++ b/src/tracer/inject_syscall.rs
@@ -1,5 +1,6 @@
 use libc::{c_int, c_long, c_ulong, c_void, off_t, pid_t, size_t, ssize_t, SYS_munmap};
 use libc::{SYS_getpid, SYS_ioctl, SYS_mmap};
+use log::debug;
 use nix::sys::signal::Signal;
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::Pid;
@@ -380,7 +381,9 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
+        debug!("tracer cleanup started");
         let _ = deinit(self); // its ok if it was already deinited
+        debug!("tracer cleanup stopped");
     }
 }
 

--- a/src/tracer/inject_syscall.rs
+++ b/src/tracer/inject_syscall.rs
@@ -383,7 +383,7 @@ impl Drop for Process {
     fn drop(&mut self) {
         debug!("tracer cleanup started");
         let _ = deinit(self); // its ok if it was already deinited
-        debug!("tracer cleanup stopped");
+        debug!("tracer cleanup finished");
     }
 }
 

--- a/src/tracer/wrap_syscall.rs
+++ b/src/tracer/wrap_syscall.rs
@@ -195,9 +195,11 @@ pub struct KvmRunWrapper {
 
 impl Drop for KvmRunWrapper {
     fn drop(&mut self) {
+        debug!("kvm run wrapper cleanup started");
         if let Err(e) = self.prepare_detach() {
             log::warn!("cannot drop KvmRunWrapper: {}", e);
         }
+        debug!("kvm run wrapper cleanup finished");
     }
 }
 


### PR DESCRIPTION
It's still not perfect.
The block device driver cannot re-attach.
But at least it no longer crashes the VM.