### PR TITLE
stdin/out console: Initial skeleton

### DIFF
--- a/src/devices/virtio/console/mod.rs
+++ b/src/devices/virtio/console/mod.rs
@@ -1,5 +1,7 @@
 mod device;
 mod log_handler;
+mod stdin_stdout_device;
+mod stdin_stdout_handler;
 
 use std::io;
 

--- a/src/devices/virtio/console/stdin_stdout_device.rs
+++ b/src/devices/virtio/console/stdin_stdout_device.rs
@@ -1,0 +1,243 @@
+use std::sync::{Arc, Mutex};
+
+use std::fs::OpenOptions;
+use virtio_queue::Queue;
+use vm_memory::GuestAddressSpace;
+
+use super::{build_config_space, ConsoleArgs, Error, Result, CONSOLE_DEVICE_ID};
+use crate::devices::use_ioregionfd;
+use crate::devices::virtio::console::stdin_stdout_handler::StdinStdoutHandler;
+use crate::devices::virtio::console::VIRTIO_CONSOLE_F_SIZE;
+use crate::devices::virtio::{
+    features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1},
+    register_ioeventfd,
+};
+use crate::devices::virtio::{IrqAckHandler, MmioConfig, SingleFdSignalQueue, QUEUE_MAX_SIZE};
+use crate::devices::MaybeIoRegionFd;
+use crate::kvm::hypervisor::{
+    ioevent::IoEvent, ioregionfd::IoRegionFd, userspaceioeventfd::UserspaceIoEventFd, Hypervisor,
+};
+use event_manager::{MutEventSubscriber, RemoteEndpoint, Result as EvmgrResult, SubscriberId};
+use std::borrow::{Borrow, BorrowMut};
+use std::ops::DerefMut;
+use virtio_device::{VirtioConfig, VirtioDevice, VirtioDeviceType};
+use virtio_device::{VirtioDeviceActions, VirtioMmioDevice, VirtioQueueNotifiable};
+use vm_device::bus::MmioAddress;
+use vm_device::device_manager::MmioManager;
+use vm_device::{DeviceMmio, MutDeviceMmio};
+use vmm_sys_util::eventfd::EventFd;
+
+use simple_error::map_err_with;
+
+pub struct StdConsole<M: GuestAddressSpace> {
+    virtio_cfg: VirtioConfig<M>,
+    pub mmio_cfg: MmioConfig,
+    endpoint: RemoteEndpoint<Arc<Mutex<dyn MutEventSubscriber + Send>>>,
+    pub irq_ack_handler: Arc<Mutex<IrqAckHandler>>,
+    vmm: Arc<Hypervisor>,
+    irqfd: Arc<EventFd>,
+    pub ioregionfd: Option<IoRegionFd>,
+    pub uioefd: UserspaceIoEventFd,
+    /// only used when ioregionfd != None
+    sub_id: Option<SubscriberId>,
+
+    // Before resetting we return the handler to the mmio thread for cleanup
+    #[allow(dead_code)]
+    handler: Option<Arc<Mutex<dyn MutEventSubscriber + Send>>>,
+}
+
+impl<M> StdConsole<M>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+{
+    pub fn new<B>(mut args: ConsoleArgs<M, B>) -> Result<Arc<Mutex<Self>>>
+    where
+        // We're using this (more convoluted) bound so we can pass both references and smart
+        // pointers such as mutex guards here.
+        B: DerefMut,
+        B::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
+    {
+        let device_features = 1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_IN_ORDER
+            | 1 << VIRTIO_F_RING_EVENT_IDX
+            | 1 << VIRTIO_CONSOLE_F_SIZE;
+
+        let queues = vec![Queue::new(args.common.mem.clone(), QUEUE_MAX_SIZE); 2];
+        let config_space = build_config_space();
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let irqfd = Arc::new(
+            args.common
+                .vmm
+                .irqfd(args.common.mmio_cfg.gsi)
+                .map_err(Error::Simple)?,
+        );
+
+        let mmio_cfg = args.common.mmio_cfg;
+
+        let irq_ack_handler = Arc::new(Mutex::new(IrqAckHandler::new(
+            virtio_cfg.interrupt_status.clone(),
+            Arc::clone(&irqfd),
+        )));
+
+        let mut ioregionfd = None;
+        if use_ioregionfd() {
+            ioregionfd = Some(
+                args.common
+                    .vmm
+                    .ioregionfd(mmio_cfg.range.base().0, mmio_cfg.range.size() as usize)
+                    .map_err(Error::Simple)?,
+            );
+        }
+
+        let console = Arc::new(Mutex::new(StdConsole {
+            virtio_cfg,
+            mmio_cfg,
+            endpoint: args.common.event_mgr.remote_endpoint(),
+            irq_ack_handler,
+            vmm: args.common.vmm.clone(),
+            irqfd,
+            ioregionfd,
+            uioefd: UserspaceIoEventFd::default(),
+            sub_id: None,
+            handler: None,
+        }));
+
+        // Register the device on the MMIO bus.
+        args.common
+            .mmio_mgr
+            .register_mmio(mmio_cfg.range, console.clone())
+            .map_err(Error::Bus)?;
+
+        Ok(console)
+    }
+
+    fn _activate(&mut self) -> Result<()> {
+        if self.virtio_cfg.device_activated {
+            return Err(Error::AlreadyActivated);
+        }
+
+        // We do not support legacy drivers.
+        if self.virtio_cfg.driver_features & (1 << VIRTIO_F_VERSION_1) == 0 {
+            return Err(Error::BadFeatures(self.virtio_cfg.driver_features));
+        }
+
+        let driver_notify = SingleFdSignalQueue {
+            irqfd: self.irqfd.clone(),
+            interrupt_status: self.virtio_cfg.interrupt_status.clone(),
+            ack_handler: self.irq_ack_handler.clone(),
+        };
+
+        // TODO: replace with pty or tty
+        // stat /proc/self/fd/0 to get /dev/pts/X
+        let console = map_err_with!(
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/proc/self/fd/0"),
+            "could not open console"
+        )
+        .map_err(Error::Simple)?;
+
+        let rx_fd = register_ioeventfd(&self.vmm, &self.mmio_cfg, 0).map_err(Error::Simple)?;
+        let tx_fd = IoEvent::register(&self.vmm, &mut self.uioefd, &self.mmio_cfg, 1)
+            .map_err(Error::Simple)?;
+
+        let handler = Arc::new(Mutex::new(StdinStdoutHandler {
+            driver_notify,
+            tx_fd,
+            rxq: self.virtio_cfg.queues[0].clone(),
+            txq: self.virtio_cfg.queues[1].clone(),
+            console,
+        }));
+
+        // Register the queue handler with the `EventManager`. We record the `sub_id`
+        // (and/or keep a handler clone) to remove the subscriber when resetting the device
+        let sub_id = self
+            .endpoint
+            .call_blocking(move |mgr| -> EvmgrResult<SubscriberId> {
+                Ok(mgr.add_subscriber(handler))
+            })
+            .map_err(|e| {
+                log::warn!("{}", e);
+                Error::Endpoint(e)
+            })?;
+        self.sub_id = Some(sub_id);
+
+        log::debug!("activating device: ok");
+        self.virtio_cfg.device_activated = true;
+
+        Ok(())
+    }
+
+    fn _reset(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> MaybeIoRegionFd for StdConsole<M> {
+    fn get_ioregionfd(&mut self) -> &mut Option<IoRegionFd> {
+        &mut self.ioregionfd
+    }
+}
+
+// We now implement `WithVirtioConfig` and `WithDeviceOps` to get the automatic implementation
+// for `VirtioDevice`.
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceType for StdConsole<M> {
+    fn device_type(&self) -> u32 {
+        CONSOLE_DEVICE_ID
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> Borrow<VirtioConfig<M>> for StdConsole<M> {
+    fn borrow(&self) -> &VirtioConfig<M> {
+        &self.virtio_cfg
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> BorrowMut<VirtioConfig<M>> for StdConsole<M> {
+    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
+        &mut self.virtio_cfg
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for StdConsole<M> {
+    type E = Error;
+
+    /// make sure to set self.vmm.wrapper to Some() before activating. Typically this is done by
+    /// activating during vmm.kvmrun_wrapped()
+    fn activate(&mut self) -> Result<()> {
+        let ret = self._activate();
+        if let Err(ref e) = ret {
+            log::warn!("failed to activate console device: {:?}", e);
+        }
+        ret
+    }
+
+    fn reset(&mut self) -> Result<()> {
+        self.set_device_status(0);
+        self._reset()?;
+        Ok(())
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioQueueNotifiable for StdConsole<M> {
+    fn queue_notify(&mut self, val: u32) {
+        if use_ioregionfd() {
+            self.uioefd.queue_notify(val);
+            log::trace!("queue_notify {}", val);
+        }
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioMmioDevice<M> for StdConsole<M> {}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> MutDeviceMmio for StdConsole<M> {
+    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
+        self.read(offset, data);
+    }
+
+    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
+        self.write(offset, data);
+    }
+}

--- a/src/devices/virtio/console/stdin_stdout_handler.rs
+++ b/src/devices/virtio/console/stdin_stdout_handler.rs
@@ -1,0 +1,28 @@
+use std::fs::File;
+
+use event_manager::MutEventSubscriber;
+use virtio_queue::Queue;
+use vm_memory::GuestAddressSpace;
+
+use crate::{devices::virtio::SignalUsedQueue, kvm::hypervisor::ioevent::IoEvent};
+
+pub struct StdinStdoutHandler<M: GuestAddressSpace, S: SignalUsedQueue> {
+    /// ioevent fd to indicate new data added to the tx queue
+    pub tx_fd: IoEvent,
+    /// Notify driver about used buffers
+    pub driver_notify: S,
+    /// rx queue for sending data to the guest
+    pub rxq: Queue<M>,
+    /// tx queue for receiving data from the guest
+    pub txq: Queue<M>,
+    /// host side stream
+    pub console: File,
+}
+
+impl<M: GuestAddressSpace, S: SignalUsedQueue> StdinStdoutHandler<M, S> {}
+
+impl<M: GuestAddressSpace, S: SignalUsedQueue> MutEventSubscriber for StdinStdoutHandler<M, S> {
+    fn process(&mut self, events: event_manager::Events, ops: &mut event_manager::EventOps) {}
+
+    fn init(&mut self, ops: &mut event_manager::EventOps) {}
+}


### PR DESCRIPTION
Initial skeleton for stdin/stdout console, missing three major components:

- needs to use a /dev/pts/X
- Queue processing code for rx and tx(think its similar to current logging device?)
- Integration into vmsh