### PR TITLE
just: reliability-attach

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,6 +69,20 @@ stress-test DEV="/dev/vda":
   [ $(sha256sum {{virtio_blk_img}} | cut -c'1-64') == $(just ssh-qemu "sha256sum {{DEV}}" | cut -c'1-64') ] || echo "ok"
   echo "stress test ok"
 
+reliability-attach:
+  #!/usr/bin/env python3
+  import sys, os
+  sys.path.insert(0, os.path.join("{{justfile_directory()}}", "tests"))
+  from test_attach import test_attach
+  from conftest import Helpers
+  helpers = Helpers()
+
+  test_attach(helpers, attach_repetitions=100, vcpus=2, mmio="wrap_syscall") 
+  # rep 36, 1, 4, 3, 0, 13
+  
+  #test_attach(helpers, attach_repetitions=100, vcpus=2, mmio="ioregionfd") 
+  # rep 4, 15, 3, 45, 34, 2
+
 # Git clone linux kernel
 clone-linux:
   [[ -d {{linux_dir}} ]] || \

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -3,56 +3,61 @@ import conftest
 import os
 
 
-def test_attach(helpers: conftest.Helpers) -> None:
+def test_attach(helpers: conftest.Helpers, attach_repetitions: int = 1, vcpus: int = 1, mmio: str = "wrap_syscall") -> None:
     with helpers.busybox_image() as img, helpers.spawn_qemu(
-        helpers.notos_image()
+        helpers.notos_image(),
+        extra_args=["-smp", str(vcpus)]
     ) as vm:
         vm.wait_for_ssh()
-        vmsh = helpers.spawn_vmsh_command(
-            [
-                "attach",
-                "--backing-file",
-                str(img),
-                str(vm.pid),
-                "--",
-                "/bin/sh",
-                "-c",
-                "echo works",
-            ]
-        )
+        for i in range(attach_repetitions):
+            print(f" ======== repetition {i} ======== ")
+            vmsh = helpers.spawn_vmsh_command(
+                [
+                    "attach",
+                    "--backing-file",
+                    str(img),
+                    "--mmio",
+                    mmio,
+                    str(vm.pid),
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    "echo works",
+                ]
+            )
 
-        with vmsh:
+            with vmsh:
+                try:
+                    vmsh.wait_until_line(
+                        "stage1 driver started",
+                        lambda l: "stage1 driver started" in l,
+                    )
+                finally:
+                    res = vm.ssh_cmd(["dmesg"], check=False)
+                    print("stdout:\n", res.stdout)
+                assert res.returncode == 0
+
+                # with DeviceMmioSpace instead of KvmRunWrapper:
+                # assert (
+                #     res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0
+                # )
+                # assert (
+                #     res.stdout.find(
+                #         "New virtio-mmio devices (version 2) must provide VIRTIO_F_VERSION_1 feature!"
+                #     )
+                #     >= 0
+                # )
+
+                # with KvmRunWrapper:
+                assert res.stdout.find("ext4 filesystem being mounted at /tmp/") > 0
             try:
-                vmsh.wait_until_line(
-                    "stage1 driver started",
-                    lambda l: "stage1 driver started" in l,
-                )
-            finally:
-                res = vm.ssh_cmd(["dmesg"], check=False)
-                print("stdout:\n", res.stdout)
+                os.kill(vmsh.pid, 0)
+            except ProcessLookupError:
+                pass
+            else:
+                assert False, "vmsh was not terminated properly"
+
+            # See that the VM is still alive after detaching
+            res = vm.ssh_cmd(["echo", "ping"], check=False)
+            assert res.stdout == "ping\n"
             assert res.returncode == 0
-
-            # with DeviceMmioSpace instead of KvmRunWrapper:
-            # assert (
-            #     res.stdout.find("virtio_mmio: unknown parameter 'device' ignored") < 0
-            # )
-            # assert (
-            #     res.stdout.find(
-            #         "New virtio-mmio devices (version 2) must provide VIRTIO_F_VERSION_1 feature!"
-            #     )
-            #     >= 0
-            # )
-
-            # with KvmRunWrapper:
-            assert res.stdout.find("ext4 filesystem being mounted at /tmp/") > 0
-        try:
-            os.kill(vmsh.pid, 0)
-        except ProcessLookupError:
-            pass
-        else:
-            assert False, "vmsh was not terminated properly"
-
-        # See that the VM is still alive after detaching
-        res = vm.ssh_cmd(["echo", "ping"], check=False)
-        assert res.stdout == "ping\n"
-        assert res.returncode == 0


### PR DESCRIPTION
measurements suggest that ioregionfd is more stable than wrap_syscall with 2 vcpus. I see two possible explanations:
- wrap_syscall does more wrap_syscal <-> inject_syscall transformations. The transformation is error prone.
- wrap_syscall impacts guest vcpus more and leads to higher likeliness of uncommon scheduling or whatever which breaks inject_syscall or code injection. Inject_syscall or code injection is error prone. 